### PR TITLE
V1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
   <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data linage for BigData Projects.
   Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -62,7 +62,48 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   
    //Validating GlobalSettings
   println("Validating GlobalSetings..")
-  //if (this. globalSettings.RAW_BigFiles_Path
+  var ErrorGlobalSettings: String = ""
+  if (!this.GlobalSettings.ValidPath(globalSettings.RAW_SmallFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}RAW_SmallFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.RAW_BigFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}RAW_BigFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.MASTER_SmallFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}MASTER_SmallFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.MASTER_BigFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}MASTER_BigFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.MASTER_DataBase, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}MASTER_DataBase"
+  if (!this.GlobalSettings.ValidPath(globalSettings.DIM_SmallFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}DIM_SmallFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.DIM_BigFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}DIM_BigFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.DIM_DataBase, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}DIM_DataBase"
+  if (!this.GlobalSettings.ValidPath(globalSettings.REPORTING_SmallFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}REPORTING_SmallFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.REPORTING_BigFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}REPORTING_BigFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.REPORTING_DataBase, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}REPORTING_DataBase"
+  if (!this.GlobalSettings.ValidPath(globalSettings.ANALYTICS_SmallFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}ANALYTICS_SmallFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.ANALYTICS_BigFiles_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}ANALYTICS_BigFiles_Path"
+  if (!this.GlobalSettings.ValidPath(globalSettings.ANALYTICS_DataBase, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}ANALYTICS_DataBase"
+  if (!this.GlobalSettings.ValidPath(globalSettings.TEMPORAL_Path, this.Environment))
+    ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}TEMPORAL_Path"
+  
+  if (this.GlobalSettings.DQ_SaveErrorDetails) {
+    if (!this.GlobalSettings.ValidPath(globalSettings.DQError_Path, this.Environment))
+      ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}DQError_Path"
+    if (!this.GlobalSettings.ValidPath(globalSettings.DQError_DataBase, this.Environment))
+      ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}DQError_DataBase"
+  }
+  
+  if (ErrorGlobalSettings.length()> 0) {
+    sys.error(s"Error: GlobalSettings incomplete!!, you must set $ErrorGlobalSettings ")
+  }
   
   
   val Malla_Id: String = arguments.GetValue("Malla_Id", "" )

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -44,8 +44,10 @@ import org.apache.spark.sql.catalyst.expressions.Coalesce
  *  @constructor create a new person with a name and age.
  *  @param appName nombre de la aplicación
  *  @param args argumentos de la aplicación
+ *  @param globalSettings configuración de rutas y Bases de datos
+ *  @param LocalSparkSession(opcional) permite enviar una sesión de Spark ya iniciada.
  */
-class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath) extends Serializable  {
+class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null) extends Serializable  {
   val GlobalSettings = globalSettings
   val warehouseLocation = new File("spark-warehouse").getAbsolutePath
   
@@ -169,12 +171,15 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   if (!TestPlanMode && ImpalaEnabled)
       impala_connection.StartConnection()
   
-  val spark: SparkSession = if (!TestPlanMode) SparkSession.builder().appName(appName)
+  val spark: SparkSession = if (!TestPlanMode & LocalSparkSession == null) 
+                                      SparkSession.builder().appName(appName)
                                               //.master("local[*]")
                                               .config("spark.sql.warehouse.dir", warehouseLocation)
                                               .config("spark.sql.parquet.writeLegacyFormat",true)
                                               .enableHiveSupport()
                                               .getOrCreate()
+                            else if (!TestPlanMode & LocalSparkSession != null)
+                                      LocalSparkSession
                             else null
 
   if (!TestPlanMode) {

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -342,6 +342,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
       val FileToTemp: String = GlobalSettings.GetDebugTempPath(this, ProcessNameCall, Alias) + ".parquet"      
       println(s"path result for table alias $Alias: $FileToTemp ")
       //version 1.3 --> prueba para optimizar escritura temporal
+      //Se aplica coalesce en vez de repartition para evitar el shuffle interno
       if (NumPartitionCoalesce == null || NumPartitionCoalesce == 0)
         DF.write.mode(SaveMode.Overwrite).parquet(FileToTemp)
       else

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -61,7 +61,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   
   
    //Validating GlobalSettings
-  println("Validating GlobalSetings..")
+  println("Start Validating GlobalSetings..")
   var ErrorGlobalSettings: String = ""
   if (!this.GlobalSettings.ValidPath(globalSettings.RAW_SmallFiles_Path, this.Environment))
     ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}RAW_SmallFiles_Path"
@@ -100,6 +100,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     if (!this.GlobalSettings.ValidPath(globalSettings.DQError_DataBase, this.Environment))
       ErrorGlobalSettings += s"${if (ErrorGlobalSettings.length() > 0) ", " else ""}DQError_DataBase"
   }
+  println("End Validating GlobalSetings..")
   
   if (ErrorGlobalSettings.length()> 0) {
     sys.error(s"Error: GlobalSettings incomplete!!, you must set $ErrorGlobalSettings ")

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -51,7 +51,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * ARGUMENTS
    *************************/
-  println("huemul_BigDataGovernance version 1.2.0 - sv01")
+  println("huemul_BigDataGovernance version 1.3.0 - sv01")
    
       
         

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -53,13 +53,18 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
    * ARGUMENTS
    *************************/
   println("huemul_BigDataGovernance version 1.3.0 - sv01")
-   
-      
-        
-        
+  
+       
   val arguments: huemul_Args = new huemul_Args()
   arguments.setArgs(args)  
   val Environment: String = arguments.GetValue("Environment", null, s"MUST be set environment parameter: '${GlobalSettings.GlobalEnvironments}' " )
+  
+  
+   //Validating GlobalSettings
+  println("Validating GlobalSetings..")
+  //if (this. globalSettings.RAW_BigFiles_Path
+  
+  
   val Malla_Id: String = arguments.GetValue("Malla_Id", "" )
   var HideLibQuery: Boolean = false
   try {

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -90,9 +90,16 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
   /**   
    Create DF from SQL (equivalent to spark.sql method)
    */
-  def DF_from_SQL(Alias: String, sql: String, SaveInTemp: Boolean = true) {
+  def DF_from_SQL(Alias: String, sql: String, SaveInTemp: Boolean = true, NumPartitions: Integer = null) {
     if (huemulBigDataGov.DebugMode && !huemulBigDataGov.HideLibQuery) println(sql)
-    val DFTemp = huemulBigDataGov.spark.sql(sql)
+    
+    
+    //val DFTemp = huemulBigDataGov.spark.sql(sql)
+                 
+                 
+    val DFTemp = if (NumPartitions == null || NumPartitions <= 0) huemulBigDataGov.spark.sql(sql)
+                 else huemulBigDataGov.spark.sql(sql).repartition(NumPartitions)
+                 
     
     setDataFrame(DFTemp, Alias, SaveInTemp)
         

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -93,13 +93,10 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
   def DF_from_SQL(Alias: String, sql: String, SaveInTemp: Boolean = true, NumPartitions: Integer = null) {
     if (huemulBigDataGov.DebugMode && !huemulBigDataGov.HideLibQuery) println(sql)
     
-    
-    //val DFTemp = huemulBigDataGov.spark.sql(sql)
-                 
-                 
+    //Cambio en v1.3: optimiza tiempo al aplicar repartition para archivos pequeños             
     val DFTemp = if (NumPartitions == null || NumPartitions <= 0) huemulBigDataGov.spark.sql(sql)
                  else huemulBigDataGov.spark.sql(sql).repartition(NumPartitions)
-                 
+      
     
     setDataFrame(DFTemp, Alias, SaveInTemp)
         

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -17,7 +17,7 @@ import org.apache.spark.storage.StorageLevel._
  * Def_Fabric_DataInfo: Define method to improve DQ over DF
  */
 class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_Control) extends Serializable {
-  
+  private val numPartitionsForTempFiles: Integer = 2
   if (Control == null) 
     sys.error("Control is null in huemul_DataFrame")
     
@@ -84,7 +84,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     //TODO: ver como poner la fecha de término de lectura StopRead_dt = Calendar.getInstance()
         
     if (SaveInTemp)
-      huemulBigDataGov.CreateTempTable(DataDF, AliasDF, huemulBigDataGov.DebugMode)
+      huemulBigDataGov.CreateTempTable(DataDF, AliasDF, huemulBigDataGov.DebugMode, null)
   }
   
   /**   
@@ -395,7 +395,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
       DQResult.dqDF = huemulBigDataGov.spark.sql(SQL)
             
       if (huemulBigDataGov.DebugMode) DQResult.dqDF.show()        
-      huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_StatsByCol_${Col}",huemulBigDataGov.DebugMode)
+      huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_StatsByCol_${Col}",huemulBigDataGov.DebugMode, numPartitionsForTempFiles)
       
       val FirstRow = DQResult.dqDF.first()
       DQResult.profilingResult.max_Col = FirstRow.getAs[String]("max_Col")   
@@ -444,7 +444,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         DQResult.dqDF.printSchema()
         DQResult.dqDF.show()
       }
-      huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_StatsByFunction_${function}",huemulBigDataGov.DebugMode)
+      huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_StatsByFunction_${function}",huemulBigDataGov.DebugMode, numPartitionsForTempFiles)
       
     } catch {
       case e: Exception => {
@@ -490,7 +490,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         var TempFileName_local = TempFileName
         if (TempFileName_local == null)
           TempFileName_local = ColDuplicate
-        huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_DupliVal_${TempFileName_local}",huemulBigDataGov.DebugMode)
+        huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_DupliVal_${TempFileName_local}",huemulBigDataGov.DebugMode, numPartitionsForTempFiles)
       }
       
       //duplicate rows found
@@ -563,7 +563,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         DQResult.dqDF.show()
         
       }
-      huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_NotNullValues_${Col}",huemulBigDataGov.DebugMode)
+      huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_NotNullValues_${Col}",huemulBigDataGov.DebugMode, numPartitionsForTempFiles)
       
       //null rows found
       DQDup = DQResult.dqDF.count()

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -58,6 +58,14 @@ class huemul_GlobalPath() extends Serializable {
     val DQError_Path: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     val DQError_DataBase: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     
+    /**
+     Returns true if path has value, otherwise return false
+     */
+    def ValidPath(Division: ArrayBuffer[huemul_KeyValuePath], ManualEnvironment: String): Boolean = {
+      val Result = Division.filter { x => x.environment == ManualEnvironment }
+      return if (Result == null || Result.length == 0) false else true
+    }
+    
     def GetPath(huemulBigDataGov: huemul_BigDataGovernance, Division: ArrayBuffer[huemul_KeyValuePath]): String = {
       val Result = Division.filter { x => x.environment == huemulBigDataGov.Environment }
       if (Result == null || Result.length == 0)

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -237,11 +237,12 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
   }
   
   def FinishProcessError() {
-    
+
+    if (Control_IdParent == null) println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ERROR")
+    println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ProcessExec_Id: ${Control_Id}, processName: ${Control_ClassName}")
+
       
     if (huemulBigDataGov.RegisterInControl) {
-      if (Control_IdParent == null) println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ERROR")
-      println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ProcessExec_Id: ${Control_Id}, processName: ${Control_ClassName}")
     
       val Error_Id = huemulBigDataGov.huemul_GetUniqueId()
       if (Control_Error.ControlError_Message == null)

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -227,7 +227,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
     val DiffDate = huemulBigDataGov.getDateTimeDiff(processExec_dtStart, processExec_dtEnd)
   
     if (!huemulBigDataGov.HasName(Control_IdParent)) println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ALL OK")
-    println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH processName: ${Control_ClassName}, ProcessExec_Id: ${Control_Id}, Duration: ${DiffDate.hour + (DiffDate.days*24)}:${DiffDate.minute}:${DiffDate.second} ")
+    println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH processName: ${Control_ClassName}, ProcessExec_Id: ${Control_Id}, Time Elapsed: ${DiffDate.hour + (DiffDate.days*24)}:${DiffDate.minute}:${DiffDate.second} ")
 
     if (huemulBigDataGov.RegisterInControl) {
     
@@ -245,7 +245,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
     val DiffDate = huemulBigDataGov.getDateTimeDiff(processExec_dtStart, processExec_dtEnd)
     
     if (Control_IdParent == null) println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ERROR")
-    println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH processName: ${Control_ClassName}, ProcessExec_Id: ${Control_Id}, Duration: ${DiffDate.hour + (DiffDate.days*24)}:${DiffDate.minute}:${DiffDate.second} ")
+    println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH processName: ${Control_ClassName}, ProcessExec_Id: ${Control_Id}, Time Elapsed: ${DiffDate.hour + (DiffDate.days*24)}:${DiffDate.minute}:${DiffDate.second} ")
 
       
     if (huemulBigDataGov.RegisterInControl) {

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -221,10 +221,11 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
   }
     
   def FinishProcessOK {
-    
+
+    if (!huemulBigDataGov.HasName(Control_IdParent)) println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ALL OK")
+    println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ProcessExec_Id: ${Control_Id}, processName: ${Control_ClassName}")
+
     if (huemulBigDataGov.RegisterInControl) {
-      if (!huemulBigDataGov.HasName(Control_IdParent)) println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ALL OK")
-      println(s"HuemulControlLog: [${huemulBigDataGov.huemul_getDateForLog()}] FINISH ProcessExec_Id: ${Control_Id}, processName: ${Control_ClassName}")
     
       control_processExec_Finish(Control_Id, this.LocalIdStep, null)
       

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2227,18 +2227,28 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     
     try {
       if (_PartitionField == null || _PartitionField == ""){
+        /*
+         * Se descarta esta forma, no la aplica realmente al grabar los datos
         if (this.getNumPartitions == null || this.getNumPartitions <= 0) {
           LocalControl.NewStep("Save: Set num FileParts")
           DF_Final = DF_Final.repartition(this.getNumPartitions)
         }
+        * 
+        */
         
         if (OnlyInsert) {
           LocalControl.NewStep("Save: Append Master & Ref Data")
-          DF_Final.write.mode(SaveMode.Append).format(this._StorageType.toString()).save(GetFullNameWithPath())
+          if (this.getNumPartitions == null || this.getNumPartitions <= 0)
+            DF_Final.write.mode(SaveMode.Append).format(this._StorageType.toString()).save(GetFullNameWithPath())
+          else
+            DF_Final.repartition(this.getNumPartitions).write.mode(SaveMode.Append).format(this._StorageType.toString()).save(GetFullNameWithPath())
         }
         else {
           LocalControl.NewStep("Save: Overwrite Master & Ref Data")
-          DF_Final.write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(GetFullNameWithPath())
+          if (this.getNumPartitions == null || this.getNumPartitions <= 0)
+            DF_Final.write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(GetFullNameWithPath())
+          else
+            DF_Final.repartition(this.getNumPartitions).write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(GetFullNameWithPath())
         }
         
         //val fs = FileSystem.get(huemulBigDataGov.spark.sparkContext.hadoopConfiguration)       
@@ -2258,15 +2268,21 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           val fs = FileSystem.get(huemulBigDataGov.spark.sparkContext.hadoopConfiguration)       
           fs.delete(FullPath, true)
           
+          /*
           if (this.getNumPartitions == null || this.getNumPartitions <= 0){
             LocalControl.NewStep("Save: Set num FileParts")
             DF_Final = DF_Final.repartition(this.getNumPartitions)
           }
+          * 
+          */
           
           LocalControl.NewStep("Save: OverWrite partition with new data")
           if (huemulBigDataGov.DebugMode) println(s"saving path: ${FullPath} ")     
           
-          DF_Final.write.mode(SaveMode.Append).format(this._StorageType.toString()).partitionBy(_PartitionField).save(GetFullNameWithPath())
+          if (this.getNumPartitions == null || this.getNumPartitions <= 0)
+            DF_Final.write.mode(SaveMode.Append).format(this._StorageType.toString()).partitionBy(_PartitionField).save(GetFullNameWithPath())
+          else
+            DF_Final.repartition(this.getNumPartitions).write.mode(SaveMode.Append).format(this._StorageType.toString()).partitionBy(_PartitionField).save(GetFullNameWithPath())
                 
           //fs.setPermission(new org.apache.hadoop.fs.Path(GetFullNameWithPath()), new FsPermission("770"))
   

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1929,8 +1929,12 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       RaiseError(s"huemul_Table Error: ${_TableType} found, Master o Reference required ", 1007)
       
     //if (this._NumRows_Total < 1000000)
-    if (storageLevelOfDF != null)
+    if (storageLevelOfDF != null) {
+      //println("***** cache")
       this.DataFramehuemul.DataFrame.persist(storageLevelOfDF)
+      }
+    //else 
+      //println("***** sin cache")
   }
   
   private def UpdateStatistics(LocalControl: huemul_Control, TypeOfCall: String) {

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1894,27 +1894,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       val SQLFullJoin_DF = huemulBigDataGov.DF_ExecuteQuery("__FullJoin"
                                               , SQL_Step1_FullJoin(TempAlias, NextAlias, isUpdate, isDelete)
                                              )
-      var toMemory: Boolean = false
-      //if (SQLFullJoin_DF.count() <= 1000000)
-      //  toMemory = true
                         
       //STEP 2: Create Tabla with Update and Insert result
       LocalControl.NewStep("Ref & Master: Update & Insert Logic")
       val SQLHash_p1_DF = huemulBigDataGov.DF_ExecuteQuery("__Hash_p1"
                                           , SQL_Step2_UpdateAndInsert("__FullJoin", huemulBigDataGov.ProcessNameCall, isInsert)
                                          )
-      if (toMemory)
-        SQLHash_p1_DF.cache()
-      
+     
       //STEP 3: Create Hash
       LocalControl.NewStep("Ref & Master: Hash Code")                                         
       val SQLHash_p2_DF = huemulBigDataGov.DF_ExecuteQuery("__Hash_p2"
                                           , SQL_Step3_Hash_p1("__Hash_p1", false)
                                          )
                                          
-      if (toMemory)
-        SQLHash_p2_DF.cache()
-               
                                         
       this.UpdateStatistics(LocalControl, "Ref & Master")
       

--- a/src/test/scala/samples/globalSettings.scala
+++ b/src/test/scala/samples/globalSettings.scala
@@ -75,6 +75,14 @@ object globalSettings {
    
    Global.SANDBOX_BigFiles_Path.append(new huemul_KeyValuePath("production","hdfs:///user/data/production/sandbox/"))
    Global.SANDBOX_BigFiles_Path.append(new huemul_KeyValuePath("experimental","hdfs:///user/data/experimental/sandbox/"))
+   
+   //DQ_ERROR SETTING
+   Global.DQ_SaveErrorDetails = true
+   Global.DQError_DataBase.append(new huemul_KeyValuePath("production","production_DQError"))
+   Global.DQError_DataBase.append(new huemul_KeyValuePath("experimental","experimental_DQError"))
+   
+   Global.DQError_Path.append(new huemul_KeyValuePath("production","hdfs:///user/data/production/dqerror/"))
+   Global.DQError_Path.append(new huemul_KeyValuePath("experimental","hdfs:///user/data/experimental/dqerror/"))
 
 }
 


### PR DESCRIPTION
**Se implementan las siguientes mejoras:**

1. Mejora en mensajes de finalización de procesos en modo RegisterInControl=false
2. #24 SetNumPartition
3. #24 Se agrega opción de N° de particiones al ejecutar DF_From_SQL (DF_from_SQL(Alias: String, sql: String, SaveInTemp: Boolean = true, NumPartitions: Integer = null)
4. #25 validación de seteo de variables de GlobalSettings
5. #27 Mejora en mensajes de finalización: se agrega tiempo transcurrido por cada proceso
6. #28 se agrega sesión de spark enviada por usuario (huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null)
7. #29 agrega parametros a método execute
	- executeFull(NewAlias: String, storageLevelOfDF: org.apache.spark.storage.StorageLevel = null)
	- executeOnlyInsert(NewAlias: String, storageLevelOfDF: org.apache.spark.storage.StorageLevel = null):
	- executeOnlyUpdate(NewAlias: String, storageLevelOfDF: org.apache.spark.storage.StorageLevel = null)
	- executeSelectiveUpdate(NewAlias: String, PartitionValueForSelectiveUpdate: String, storageLevelOfDF: org.apache.spark.storage.StorageLevel = null)
	
