### PR TITLE
Version 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
   <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>2.0.1</version>
+  <version>2.1</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data lineage for BigData Projects.
   Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.

--- a/src/main/resources/Instalacion/drop tables.txt
+++ b/src/main/resources/Instalacion/drop tables.txt
@@ -1,4 +1,5 @@
 
+drop table control_config;
 
 drop table  control_executors ;
 

--- a/src/main/resources/Instalacion/huemul_bdg_2.1_minor.sql
+++ b/src/main/resources/Instalacion/huemul_bdg_2.1_minor.sql
@@ -1,0 +1,468 @@
+
+CREATE TABLE control_config (   config_id		int
+				 				,version_mayor	int
+				                ,version_minor	int
+				                ,version_patch	int
+								,config_dtlog	varchar(50)
+								,primary key (config_id));
+
+create table  control_executors (
+                                              application_id         varchar(100)
+                                             ,idsparkport            varchar(50)
+                                             ,idportmonitoring       varchar(500)
+                                             ,executor_dtstart       varchar(30)
+                                             ,executor_name          varchar(100)
+                                             ,primary key (application_id)
+                                            );
+
+create table  control_singleton (
+                                              singleton_id         varchar(100)
+                                             ,application_id       varchar(100)
+                                             ,singleton_name       varchar(100)
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,primary key (singleton_id)
+                                            );
+        
+create table  control_area (
+                                              area_id              varchar(50)
+											 ,area_idpadre		   varchar(50)
+                                             ,area_name            varchar(100)
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,mdm_processname      varchar(200)
+                                             ,primary key (area_id)
+                                            );
+                             
+create table  control_process ( 
+                                              process_id           varchar(200)
+                                             ,area_id              varchar(50)
+                                             ,process_name         varchar(200)
+                                             ,process_filename     varchar(200)
+                                             ,process_description  varchar(1000)
+                                             ,process_owner        varchar(200)
+											 ,process_frequency    varchar(50)
+                                             ,mdm_manualchange     int
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,mdm_processname      varchar(200)
+                                             ,primary key (process_id)
+                                            );
+                             
+create table  control_processexec ( 
+                                              processexec_id          varchar(50)
+                                             ,processexec_idparent    varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,malla_id                varchar(50)
+                                             ,application_id          varchar(100)
+                                             ,processexec_isstart     int
+                                             ,processexec_iscancelled int
+                                             ,processexec_isenderror  int
+                                             ,processexec_isendok     int
+                                             ,processexec_dtstart     varchar(30)
+                                             ,processexec_dtend       varchar(30)
+                                             ,processexec_durhour     int
+                                             ,processexec_durmin      int
+                                             ,processexec_dursec      int
+                                             ,processexec_whosrun     varchar(200)
+                                             ,processexec_debugmode   int
+                                             ,processexec_environment varchar(200)
+											 ,processexec_param_year	int 
+											 ,processexec_param_month	int 
+											 ,processexec_param_day		int 
+											 ,processexec_param_hour	int 
+											 ,processexec_param_min		int 
+											 ,processexec_param_sec		int 
+											 ,processexec_param_others	varchar(1000) 
+											 ,processexec_huemulversion varchar(50)
+											 ,processexec_controlversion varchar(50)
+                                             ,error_id                varchar(50)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexec_id) 
+                                            );
+                             
+create table  control_processexecparams ( 
+                                              processexec_id          varchar(50)
+                                             ,processexecparams_name  varchar(500)
+                                             ,processexecparams_value varchar(4000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexec_id, processexecparams_name) 
+                                            );
+                   
+create table  control_processexecstep ( 
+                                              processexecstep_id      varchar(50)
+                                             ,processexec_id          varchar(50)
+                                             ,processexecstep_name        varchar(200)
+                                             ,processexecstep_status      varchar(20)  
+                                             ,processexecstep_dtstart     varchar(30)
+                                             ,processexecstep_dtend       varchar(30)
+                                             ,processexecstep_durhour     int
+                                             ,processexecstep_durmin      int
+                                             ,processexecstep_dursec      int
+                                             ,error_id                varchar(50)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexecstep_id) 
+                                            );
+                                            
+                                            
+create table control_query 		(query_id			     varchar(50)
+								,processexecstep_id      varchar(50)
+                                ,processexec_id          varchar(50)      
+                                ,rawfiles_id             varchar(50)
+                                ,rawfilesdet_id		     varchar(50)
+                                ,table_id                varchar(50)
+                                ,query_alias			 varchar(200)
+                                ,query_sql_from		     varchar(4000)
+                                ,query_sql_where		 varchar(4000)
+                                ,query_numerrors	     int
+                                ,query_autoinc			 int
+                                ,query_israw			 int
+                                ,query_isfinaltable	     int
+                                ,query_isquery			 int
+                                ,query_isreferenced		 int
+                                ,query_numrows_real		 int
+                                ,query_numrows_expected  int
+                                ,query_duration_hour	 int
+                                ,query_duration_min		 int
+                                ,query_duration_sec		 int			 
+                                ,error_id                varchar(50)
+                                ,mdm_fhcreate            varchar(30)
+                                ,mdm_processname         varchar(200)    
+                                ,primary key (query_id)
+                                );
+                                
+create table control_querycolumn 	  (querycol_id					varchar(50)
+									  ,query_id						varchar(50)
+									  ,rawfilesdet_id               varchar(50)
+									  ,column_id                  	varchar(50)
+									  ,querycol_pos					int
+									  ,querycol_name				varchar(200)
+									  ,querycol_sql					varchar(4000)
+									  ,querycol_posstart			int
+									  ,querycol_posend				int
+									  ,querycol_line				int
+									  ,mdm_fhcreate            varchar(30)
+                                	  ,mdm_processname         varchar(200)    
+									  ,primary key (querycol_id)
+                                );
+                                
+create index idx_control_querycolumn_i01 on control_querycolumn (query_id, querycol_name);
+                                
+create table control_querycolumnori		(querycolori_id					varchar(50)       
+										,querycol_id					varchar(50)
+										,table_idori                	varchar(50)
+										,column_idori					varchar(50)
+										,rawfilesdet_idori             	varchar(50)
+										,rawfilesdetfields_idori		varchar(50)
+										,query_idori					varchar(50)
+										,querycol_idori					varchar(50)
+										,querycolori_dbname				varchar(200)
+										,querycolori_tabname			varchar(200)
+										,querycolori_tabalias		 	varchar(200)
+										,querycolori_colname			varchar(200)	
+										,querycolori_isselect			int
+										,querycolori_iswhere			int
+										,querycolori_ishaving			int
+										,querycolori_isorder			int
+										,mdm_fhcreate            varchar(30)
+                                		,mdm_processname         varchar(200)    
+										,primary key (querycolori_id)
+                                );				                 
+									                                                                     
+                    
+create table  control_rawfiles ( 
+                                              rawfiles_id             varchar(50)
+                                             ,area_id                 varchar(50)
+                                             ,rawfiles_logicalname    varchar(500)
+                                             ,rawfiles_groupname      varchar(500)
+                                             ,rawfiles_description    varchar(1000)
+                                             ,rawfiles_owner          varchar(200)
+                                             ,rawfiles_frequency      varchar(200)
+                                             ,mdm_manualchange        int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfiles_id) 
+                                            );
+
+create index idx_control_rawfiles_i01 on control_rawfiles (rawfiles_logicalname, rawfiles_groupname);
+create unique index idx_control_rawfiles_i02 on control_rawfiles (rawfiles_logicalname);
+                                    
+create table  control_rawfilesdet ( 
+                                              rawfilesdet_id                            varchar(50)
+                                             ,rawfiles_id                               varchar(50)
+                                             ,rawfilesdet_startdate                     varchar(30)
+                                             ,rawfilesdet_enddate                       varchar(30)
+                                             ,rawfilesdet_filename                      varchar(1000)
+                                             ,rawfilesdet_localpath                     varchar(1000)
+                                             ,rawfilesdet_globalpath                    varchar(1000)
+                                             ,rawfilesdet_data_colseptype         varchar(50)
+                                             ,rawfilesdet_data_colsep             varchar(50)
+                                             ,rawfilesdet_data_headcolstring      varchar(4000)
+                                             ,rawfilesdet_log_colseptype          varchar(50)
+                                             ,rawfilesdet_log_colsep              varchar(50)
+                                             ,rawfilesdet_log_headcolstring       varchar(4000)
+                                             ,rawfilesdet_log_numrowsfield         varchar(200)
+                                             ,rawfilesdet_contactname                   varchar(200)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesdet_id) 
+                                            );
+
+create index idx_control_rawfilesdet_i01 on control_rawfilesdet (rawfiles_id, rawfilesdet_startdate);
+                                                       
+create table  control_rawfilesdetfields ( 
+                                              rawfilesdet_id                  varchar(50)
+											 ,rawfilesdetfields_logicalname          varchar(200)
+                                             ,rawfilesdetfields_itname          varchar(200)
+                                             ,rawfilesdetfields_description          varchar(1000)
+                                             ,rawfilesdetfields_datatype            varchar(50)
+                                             ,rawfilesdetfields_position      int
+                                             ,rawfilesdetfields_posini        int
+                                             ,rawfilesdetfields_posfin        int
+                                             ,rawfilesdetfields_applytrim     int
+                                             ,rawfilesdetfields_convertnull   int
+											 ,mdm_active			  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesdet_id, rawfilesdetfields_logicalname) 
+                                            );
+											
+                  
+create table  control_rawfilesuse ( 
+                                              rawfilesuse_id          varchar(50)
+                                             ,rawfiles_id             varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,rawfilesuse_year        int
+                                             ,rawfilesuse_month       int
+                                             ,rawfilesuse_day         int
+                                             ,rawfilesuse_hour        int
+                                             ,rawfilesuse_minute       int
+                                             ,rawfilesuse_second      int
+                                             ,rawfilesuse_params      varchar(1000)
+                                             ,rawfiles_fullname       varchar(1000)
+                                             ,rawfiles_fullpath       varchar(1000)
+                                             ,rawfiles_numrows        varchar(50)
+                                             ,rawfiles_headerline     varchar(4000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesuse_id) 
+                                            );
+                   
+create table  control_tables ( 
+                                              table_id                varchar(50)
+                                             ,area_id                 varchar(50)
+                                             ,table_bbddname          varchar(200)
+                                             ,table_name              varchar(200)
+                                             ,table_description       varchar(1000)
+                                             ,table_businessowner     varchar(200)
+                                             ,table_itowner           varchar(200)
+                                             ,table_partitionfield    varchar(200)
+                                             ,table_tabletype         varchar(50)  
+											 ,table_compressiontype   varchar(50)  
+                                             ,table_storagetype       varchar(50)
+                                             ,table_localpath         varchar(1000)
+                                             ,table_globalpath        varchar(1000)
+                                             ,table_fullname_dq		  varchar(1200)
+                                             ,table_dq_isused		  int
+                                             ,table_fullname_ovt	  varchar(1200)
+                                             ,table_ovt_isused		  int                                             
+                                             ,table_sqlcreate         varchar(4000)
+											 ,table_frequency		  varchar(200)
+											 ,table_autoincupdate     int
+											 ,table_backup		 	  int
+                                             ,mdm_manualchange        int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)                                             
+                                             ,primary key (table_id) 
+                                            );
+
+create unique index idx_control_tables_i01 on control_tables (table_bbddname, table_name );
+                   
+create table  control_tablesrel (                   
+                                              tablerel_id               varchar(50)
+                                             ,table_idpk                varchar(50)
+                                             ,table_idfk                varchar(50)
+                                             ,tablefk_namerelationship  varchar(100)
+                                             ,tablerel_validnull        int
+                                             ,mdm_manualchange          int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)                                             
+                                             ,primary key (tablerel_id) 
+                                            );
+
+create index idx_control_tablesrel_i01 on control_tablesrel (table_idpk, table_idfk, tablefk_namerelationship); 											
+                    
+create table  control_tablesrelcol ( 
+                                              tablerel_id                varchar(50)
+                                             ,column_idfk                varchar(50)
+                                             ,column_idpk                varchar(50)
+                                             ,mdm_manualchange           int
+                                             ,mdm_fhcreate               varchar(30)
+                                             ,mdm_processname            varchar(200)
+                                             ,primary key (tablerel_id, column_idfk) 
+                                            );
+                                                                       
+                    
+create table  control_columns ( 
+                                              column_id                  varchar(50)
+                                             ,table_id                   varchar(50)
+                                             ,column_position            int
+                                             ,column_name                varchar(200)
+                                             ,column_description         varchar(1000)
+                                             ,column_formula             varchar(1000)
+                                             ,column_datatype            varchar(50)
+                                             ,column_sensibledata        int
+                                             ,column_enabledtlog         int
+                                             ,column_enableoldvalue      int
+                                             ,column_enableprocesslog    int
+                                             ,column_enableoldvaluetrace int
+                                             ,column_defaultvalue        varchar(1000)
+                                             ,column_securitylevel       varchar(200)
+                                             ,column_encrypted           varchar(200)
+                                             ,column_arco                varchar(200)
+                                             ,column_nullable            int
+                                             ,column_ispk                int
+                                             ,column_isunique            int
+                                             ,column_dq_minlen           int
+                                             ,column_dq_maxlen           int 
+                                             ,column_dq_mindecimalvalue  decimal(30,10) 
+                                             ,column_dq_maxdecimalvalue  decimal(30,10) 
+                                             ,column_dq_mindatetimevalue varchar(50) 
+                                             ,column_dq_maxdatetimevalue varchar(50)
+											 ,column_dq_regexp           varchar(1000)
+											 ,column_businessglossary	 varchar(100)
+                                             ,column_responsible         varchar(100)
+                                             ,mdm_active                 int
+                                             ,mdm_manualchange           int
+                                             ,mdm_fhcreate               varchar(30)
+                                             ,mdm_processname            varchar(200)
+                                             ,primary key (column_id) 
+                                            );
+
+create index idx_control_columns_i01 on control_columns (table_id, column_name);
+                                                                       
+                   
+create table  control_tablesuse (			  tablesuse_id            varchar(50)  
+                                             ,table_id                varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,processexecstep_id      varchar(50)
+                                             ,tableuse_year        int
+                                             ,tableuse_month       int
+                                             ,tableuse_day         int
+                                             ,tableuse_hour        int
+                                             ,tableuse_minute       int
+                                             ,tableuse_second      int
+                                             ,tableuse_params      varchar(1000)
+                                             ,tableuse_read           int
+                                             ,tableuse_write          int
+                                             ,tableuse_numrowsnew     int
+                                             ,tableuse_numrowsupdate  int
+											 ,tableuse_numrowsupdatable  int
+											 ,tableuse_numrowsnochange  int
+                                             ,tableuse_numrowsmarkdelete  int
+                                             ,tableuse_numrowstotal   int
+                                             ,tableuse_numrowsexcluded			  int
+											 ,tableuse_partitionvalue varchar(200)
+											 ,tableuse_pathbackup	  varchar(1000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (tablesuse_id) 
+                                            );
+                    
+create table  control_dq (
+                                              dq_id                   varchar(50) 
+                                             ,table_id                varchar(50) 
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,column_id               varchar(50)
+                                             ,column_name             varchar(200)
+                                             ,dq_aliasdf              varchar(200)
+                                             ,dq_name                 varchar(200)
+                                             ,dq_description          varchar(1000)
+                                             ,dq_querylevel           varchar(50)
+                                             ,dq_notification         varchar(50)
+                                             ,dq_sqlformula           varchar(4000)
+                                             ,dq_dq_toleranceerror_rows     int
+                                             ,dq_dq_toleranceerror_percent     decimal(30,10)
+                                             ,dq_resultdq             varchar(4000)
+                                             ,dq_errorcode            int
+                                             ,dq_externalcode         varchar(200)
+                                             ,dq_numrowsok            int
+                                             ,dq_numrowserror         int
+                                             ,dq_numrowstotal         int
+                                             ,dq_iserror              int
+                                             ,dq_iswarning			  int
+                                             ,dq_duration_hour		  int
+                                             ,dq_duration_minute	  int
+                                             ,dq_duration_second	  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (dq_id) 
+                                            );
+                    
+                   
+create table  control_error ( 
+                                              error_id          varchar(50)
+                                             ,error_message                varchar(4000)
+                                             ,error_code           int
+                                             ,error_trace                varchar(4000)
+                                             ,error_classname                varchar(100)
+                                             ,error_filename                varchar(500)
+                                             ,error_linenumber                varchar(100)
+                                             ,error_methodname                varchar(100)
+                                             ,error_detail                varchar(500)
+                                             ,mdm_fhcrea            varchar(30)
+                                             ,mdm_processname         varchar(1000)
+                                             ,primary key (error_id)
+                                            );
+                                                                       
+                  
+create table  control_date ( 
+                                      date_id		varchar(10)
+                                      ,date_year	int
+                                      ,date_month	int
+                                      ,date_day	int
+                                      ,date_dayofweek	int
+                                      ,date_dayname	varchar(20)
+                                      ,date_monthname	varchar(20)
+                                      ,date_quarter	int
+                                      ,date_week	int
+                                      ,date_isweekend	int
+                                      ,date_isworkday	int
+                                      ,date_isbankworkday	int
+                                      ,date_numworkday		int
+                                      ,date_numworkdayrev	int
+                                      ,mdm_fhcreate            varchar(30)
+                                      ,mdm_processname         varchar(200) 
+                                      ,primary key (date_id) 
+                                      );
+                                                                       
+                 
+create table  control_testplan ( 
+                                              testplan_id             varchar(200)
+                                             ,testplangroup_id        varchar(200)
+                                             ,processexec_id          varchar(200)
+                                             ,process_id              varchar(200)
+                                             ,testplan_name           varchar(200)
+                                             ,testplan_description    varchar(1000)
+                                             ,testplan_resultexpected varchar(1000)  
+                                             ,testplan_resultreal     varchar(1000)
+                                             ,testplan_isok           int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (testplan_id) 
+                                            );
+                                            
+create index idx_control_testplan_i01 on control_testplan (testplangroup_id, testplan_name);
+                             
+
+create table  control_testplanfeature ( 
+                                              feature_id              varchar(200)
+                                             ,testplan_id             varchar(200)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (feature_id, testplan_id) 
+                                            );
+                             

--- a/src/main/resources/Instalacion/huemul_cluster_setting_2.1.sh
+++ b/src/main/resources/Instalacion/huemul_cluster_setting_2.1.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+clear
+echo "Creating HDFS Paths: START"
+hdfs dfs -mkdir /user
+hdfs dfs -mkdir /user/data
+hdfs dfs -mkdir /user/data/production
+hdfs dfs -mkdir /user/data/production/temp
+hdfs dfs -mkdir /user/data/production/raw
+hdfs dfs -mkdir /user/data/production/master
+hdfs dfs -mkdir /user/data/production/dim
+hdfs dfs -mkdir /user/data/production/analytics
+hdfs dfs -mkdir /user/data/production/reporting
+hdfs dfs -mkdir /user/data/production/sandbox
+hdfs dfs -mkdir /user/data/production/dqerror
+hdfs dfs -mkdir /user/data/production/mdm_oldvalue
+hdfs dfs -mkdir /user/data/production/backup
+hdfs dfs -mkdir /user/data/experimental
+hdfs dfs -mkdir /user/data/experimental/temp
+hdfs dfs -mkdir /user/data/experimental/raw
+hdfs dfs -mkdir /user/data/experimental/master
+hdfs dfs -mkdir /user/data/experimental/dim
+hdfs dfs -mkdir /user/data/experimental/analytics
+hdfs dfs -mkdir /user/data/experimental/reporting
+hdfs dfs -mkdir /user/data/experimental/sandbox
+hdfs dfs -mkdir /user/data/experimental/dqerror
+hdfs dfs -mkdir /user/data/experimental/mdm_oldvalue
+hdfs dfs -mkdir /user/data/experimental/backup
+echo "Creating HDFS Paths: FINISH"
+echo "STARTING HIVE SETUP"
+hive -e "CREATE DATABASE production_master"
+hive -e "CREATE DATABASE experimental_master"
+hive -e "CREATE DATABASE production_dim"
+hive -e "CREATE DATABASE experimental_dim"
+hive -e "CREATE DATABASE production_analytics"
+hive -e "CREATE DATABASE experimental_analytics"
+hive -e "CREATE DATABASE production_reporting"
+hive -e "CREATE DATABASE experimental_reporting"
+hive -e "CREATE DATABASE production_sandbox"
+hive -e "CREATE DATABASE experimental_sandbox"
+hive -e "CREATE DATABASE production_DQError"
+hive -e "CREATE DATABASE experimental_DQError"
+hive -e "CREATE DATABASE production_mdm_oldvalue"
+hive -e "CREATE DATABASE experimental_mdm_oldvalue"
+echo "STARTING HIVE SETUP"

--- a/src/main/resources/Instalacion/upgrade from 2.0 to 2.1/huemul_bdg_upgrade_2.0_to_2.1.sql
+++ b/src/main/resources/Instalacion/upgrade from 2.0 to 2.1/huemul_bdg_upgrade_2.0_to_2.1.sql
@@ -1,12 +1,14 @@
+
  ALTER TABLE control_tablesuse add tableuse_numrowsexcluded			  int;
  
  CREATE TABLE control_config (   config_id		int
 				 				,version_mayor	int
 				                ,version_minor	int
 				                ,version_patch	int
-								,config_dtlog	string
+								,config_dtlog	varchar(50)
 								,primary key (config_id));
 								
 								
-ALTER TABLE control_processexec ADD processexec_huemulversion varchar(20);
-ALTER TABLE control_processexec ADD processexec_controlversion varchar(20);
+ALTER TABLE control_processexec ADD processexec_huemulversion varchar(50);
+ALTER TABLE control_processexec ADD processexec_controlversion varchar(50);
+                             

--- a/src/main/resources/Instalacion/upgrade from 2.0 to 2.1/huemul_bdg_upgrade_2.0_to_2.1.sql
+++ b/src/main/resources/Instalacion/upgrade from 2.0 to 2.1/huemul_bdg_upgrade_2.0_to_2.1.sql
@@ -1,0 +1,10 @@
+ ALTER TABLE control_tablesuse add tableuse_numrowsexcluded			  int;
+ 
+ CREATE TABLE control_config (   config_id		int
+				 				,version_mayor	int
+				                ,version_minor	int
+				                ,version_patch	int
+								,config_dtlog	string
+								,primary key (config_id));
+								
+								

--- a/src/main/resources/Instalacion/upgrade from 2.0 to 2.1/huemul_bdg_upgrade_2.0_to_2.1.sql
+++ b/src/main/resources/Instalacion/upgrade from 2.0 to 2.1/huemul_bdg_upgrade_2.0_to_2.1.sql
@@ -8,3 +8,5 @@
 								,primary key (config_id));
 								
 								
+ALTER TABLE control_processexec ADD processexec_huemulversion varchar(20);
+ALTER TABLE control_processexec ADD processexec_controlversion varchar(20);

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -29,6 +29,7 @@ import com.huemulsolutions.bigdata.sql_decode._
 import com.huemulsolutions.bigdata.control.huemul_Control
 import org.apache.log4j.Level
 
+
         
       
 /*
@@ -51,6 +52,7 @@ import org.apache.log4j.Level
  *  @param LocalSparkSession(opcional) permite enviar una sesión de Spark ya iniciada.
  */
 class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null) extends Serializable  {
+  val currentVersion: String = "2.1"
   val GlobalSettings = globalSettings
   val warehouseLocation = new File("spark-warehouse").getAbsolutePath
   //@transient lazy val log_info = org.apache.log4j.LogManager.getLogger(s"$appName [with huemul]")
@@ -252,13 +254,14 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     log_info.error(message)
   }
   
+ 
   
   
   /*********************
    * ARGUMENTS
    *************************/
-  logMessageInfo("huemul_BigDataGovernance version 2.1 - sv1.0.3") 
-       
+  logMessageInfo(s"huemul_BigDataGovernance version ${currentVersion} - sv1.0.3")
+        
   val arguments: huemul_Args = new huemul_Args()
   arguments.setArgs(args)  
   val Environment: String = arguments.GetValue("Environment", null, s"MUST be set environment parameter: '${GlobalSettings.GlobalEnvironments}' " )

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -848,9 +848,12 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /**
    * Execute a SQL sentence, create a new alias and save de DF result into HDFS
    */
-  def DF_ExecuteQuery(Alias: String, SQL: String): DataFrame = {
+  def DF_ExecuteQuery(Alias: String, SQL: String, numPartitions: Integer = 0): DataFrame = {
     if (this.DebugMode && !HideLibQuery) logMessageDebug(SQL)        
-    val SQL_DF = this.spark.sql(SQL)            //Ejecuta Query
+    var SQL_DF = this.spark.sql(SQL)            //Ejecuta Query
+    if (numPartitions != null && numPartitions > 0)
+      SQL_DF = SQL_DF.repartition(numPartitions)      
+      
     if (this.DebugMode) SQL_DF.show()
     //Change alias name
     SQL_DF.createOrReplaceTempView(Alias)         //crea vista sql
@@ -859,9 +862,16 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     return SQL_DF
   }
   
+  /**
+   * Execute a SQL sentence, create a new alias and save de DF result into HDFS
+   */
+  def DF_ExecuteQuery(Alias: String, SQL: String): DataFrame = {
+    return DF_ExecuteQuery(Alias, SQL, 0)
+  }
+  
   def DF_ExecuteQuery(Alias: String, SQL: String, Control: huemul_Control ): DataFrame = {
     val dt_start = getCurrentDateTimeJava()
-    val Result = DF_ExecuteQuery(Alias, SQL)
+    val Result = DF_ExecuteQuery(Alias, SQL, 0)
     val dt_end = getCurrentDateTimeJava()
     
     DF_SaveLineage(Alias

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -176,7 +176,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * ARGUMENTS
    *************************/
-  logMessageInfo("huemul_BigDataGovernance version 2.1 - sv1.0") 
+  logMessageInfo("huemul_BigDataGovernance version 2.1 - sv1.0.1") 
        
   val arguments: huemul_Args = new huemul_Args()
   arguments.setArgs(args)  
@@ -265,6 +265,12 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     case e: Exception => logMessageError("ImpalaEnabled: error values (true or false)")
   }
   
+  var getHiveMetadata: Boolean = true
+  try {
+    getHiveMetadata = arguments.GetValue("getHiveMetadata", "true" ).toBoolean
+  } catch {    
+    case e: Exception => logMessageError("getHiveMetadata: error values (true or false)")
+  }
   
   /**
    * Setting Control/PostgreSQL conectivity
@@ -340,7 +346,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * GET HIVE METADATA FOR COLUMNS TRACEABILITY
    *************************/
-  if (!TestPlanMode) {
+  if (!TestPlanMode && getHiveMetadata == true) {
     logMessageInfo("Start get hive table metadata..")
     getColumnsAndTables(false)
     logMessageInfo("End get hive table metadata..")
@@ -975,7 +981,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   
   
   
-  
+  log_info.setLevel(Level.ALL)
 }
 
 

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -399,10 +399,14 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   @transient val CONTROL_connection= new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.CONTROL_Setting),GlobalSettings.CONTROL_Driver, DebugMode) // Connection = null
   @transient val impala_connection = new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.IMPALA_Setting),"com.cloudera.impala.jdbc4.Driver", DebugMode) //Connection = null
   
-  if (!TestPlanMode && RegisterInControl) 
+  if (!TestPlanMode && RegisterInControl) { 
+    logMessageInfo(s"establishing connection with control model")  
     CONTROL_connection.StartConnection()
-  if (!TestPlanMode && ImpalaEnabled)
-      impala_connection.StartConnection()
+  }
+  if (!TestPlanMode && ImpalaEnabled) {
+    logMessageInfo(s"establishing connection with impala") 
+    impala_connection.StartConnection()
+  }
   
   val spark: SparkSession = if (!TestPlanMode & LocalSparkSession == null) 
                                       SparkSession.builder().appName(appName)
@@ -438,7 +442,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * GET HIVE METADATA FOR COLUMNS TRACEABILITY
    *************************/
-  if (!TestPlanMode && getHiveMetadata == true) {
+  if (!TestPlanMode && getHiveMetadata == true && RegisterInControl) {
     logMessageInfo("Start get hive table metadata..")
     getColumnsAndTables(false)
     logMessageInfo("End get hive table metadata..")

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -176,7 +176,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * ARGUMENTS
    *************************/
-  logMessageInfo("huemul_BigDataGovernance version 2.0.1 - sv1.0") 
+  logMessageInfo("huemul_BigDataGovernance version 2.1 - sv1.0") 
        
   val arguments: huemul_Args = new huemul_Args()
   arguments.setArgs(args)  

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -260,7 +260,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * ARGUMENTS
    *************************/
-  logMessageInfo(s"huemul_BigDataGovernance version ${currentVersion} - sv1.0.3")
+  logMessageInfo(s"huemul_BigDataGovernance version ${currentVersion}")
         
   val arguments: huemul_Args = new huemul_Args()
   arguments.setArgs(args)  

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -257,7 +257,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   /*********************
    * ARGUMENTS
    *************************/
-  logMessageInfo("huemul_BigDataGovernance version 2.1 - sv1.0.2") 
+  logMessageInfo("huemul_BigDataGovernance version 2.1 - sv1.0.3") 
        
   val arguments: huemul_Args = new huemul_Args()
   arguments.setArgs(args)  
@@ -338,6 +338,14 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   } catch {    
     case e: Exception => logMessageError("SaveTempDF: error values (true or false)")
   }
+  
+  var SaveTempTables: Boolean = true
+  try {
+    SaveTempTables = arguments.GetValue("SaveTempTables", "true" ).toBoolean
+  } catch {    
+    case e: Exception => logMessageError("SaveTempTables: error values (true or false)")
+  }
+  
   
   var ImpalaEnabled: Boolean = GlobalSettings.ImpalaEnabled
   try {
@@ -650,7 +658,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
    */
   def CreateTempTable(DF: DataFrame, Alias: String, CreateTable: Boolean, NumPartitionCoalesce: Integer ) {
     //Create parquet in temp folder
-    if (CreateTable && SaveTempDF){
+    if (CreateTable && SaveTempDF && SaveTempTables){
       val FileToTemp: String = GlobalSettings.GetDebugTempPath(this, ProcessNameCall, Alias) + ".parquet"      
       logMessageInfo(s"path result for table alias $Alias: $FileToTemp ")
       //version 1.3 --> prueba para optimizar escritura temporal

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -911,7 +911,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                                       )
                                
           //Execute query
-          Control.NewStep(s"Step: DQ Result: Get detail error for (Id ${x.getId}) ${x.getDescription}, save to DF) ") 
+          //Control.NewStep(s"Step: DQ Result: Get detail error for (Id ${x.getId}) ${x.getDescription}, save to DF) ") 
           var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ", SQL_Detail)
                                
           if (dMaster == null) {

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -70,8 +70,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
   private var DQ_Result: ArrayBuffer[huemul_DQRecord] = new ArrayBuffer[huemul_DQRecord]()
   def getDQResult(): ArrayBuffer[huemul_DQRecord] = {return DQ_Result}
   
-  private def local_setDataFrame(DF: DataFrame, Alias: String, SaveInTemp: Boolean, createLineage: Boolean ) {
-    //DF.persist(MEMORY_ONLY_SER)
+  private def local_setDataFrame(DF: DataFrame, Alias: String, SaveInTemp: Boolean ) {
     DataDF = DF
     DataSchema = DF.schema
     DataDF.createOrReplaceTempView(Alias)
@@ -83,16 +82,13 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     //Data_isRead = true
     //TODO: ver como poner la fecha de término de lectura StopRead_dt = Calendar.getInstance()
     
-    if (createLineage) {
-      
-    }
-        
+            
     if (SaveInTemp)
       huemulBigDataGov.CreateTempTable(DataDF, AliasDF, huemulBigDataGov.DebugMode, null)
   }
   
   def setDataFrame(DF: DataFrame, Alias: String, SaveInTemp: Boolean = true) {
-    local_setDataFrame(DF, Alias, SaveInTemp, true /*create Lineage*/)
+    local_setDataFrame(DF, Alias, SaveInTemp)
   }
   
   
@@ -112,7 +108,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                  else huemulBigDataGov.spark.sql(sql).repartition(NumPartitions)
       
     
-    local_setDataFrame(DFTemp, Alias, SaveInTemp, false)
+    local_setDataFrame(DFTemp, Alias, SaveInTemp)
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     
     huemulBigDataGov.DF_SaveLineage(Alias
@@ -144,7 +140,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
       DFTemp.persist(storageLevelOfDF)
     }
     
-    local_setDataFrame(DFTemp, Alias, SaveInTemp, false)
+    local_setDataFrame(DFTemp, Alias, SaveInTemp)
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     
     huemulBigDataGov.DF_SaveLineage(Alias
@@ -169,7 +165,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val DF = huemulBigDataGov.spark.createDataFrame(rowRDD, DataSchema)
     
     //Assign DataFrame to LocalDataFrame
-    local_setDataFrame(DF, Alias, huemulBigDataGov.DebugMode, false)
+    local_setDataFrame(DF, Alias, huemulBigDataGov.DebugMode)
     
     //Unpersisnt unused data
     rowRDD.unpersist(false)

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -899,6 +899,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                                       ,s"not (${x.getSQLFormula()})"
                                       ,!(x.getFieldName == null) //asField
                                       ,if (x.getFieldName == null) "all" else x.getFieldName.get_MyName() //fieldName
+                                      ,Values.DQ_Id
                                       ,x.getNotification()
                                       ,x.getErrorCode()
                                       ,s"(Id ${x.getId}) ${x.getDescription}"
@@ -934,11 +935,13 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                   ,whereSQL: String
                   ,haveField: Boolean
                   ,fieldName: String
+                  ,dq_id: String
                   ,dq_error_notification: huemulType_DQNotification.huemulType_DQNotification
                   ,error_code: Integer
                   ,dq_error_description: String
                   ): String = {
     return s"""SELECT '${Control.Control_Id }' as dq_control_id
+                                     ,'${dq_id }' as dq_error_id
                                      ,'${if (haveField) fieldName else "all"}' as dq_error_columnname
                                      ,'${dq_error_notification}' as dq_error_notification 
                                      ,'${error_code}' as dq_error_code

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -208,7 +208,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     val duration = huemulBigDataGov.getDateTimeDiff(dt_start, dt_end)
       
-    val Values = new huemul_DQRecord()
+    val Values = new huemul_DQRecord(huemulBigDataGov)
     Values.Table_Name =TableName
     Values.BBDD_Name =BBDDName
     Values.DF_Alias =AliasDF
@@ -269,7 +269,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     val duration = huemulBigDataGov.getDateTimeDiff(dt_start, dt_end)
     
-    val Values = new huemul_DQRecord()
+    val Values = new huemul_DQRecord(huemulBigDataGov)
     Values.Table_Name =TableName
     Values.BBDD_Name =BBDDName
     Values.DF_Alias =AliasDF
@@ -390,7 +390,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     val duration = huemulBigDataGov.getDateTimeDiff(dt_start, dt_end)
     
-    val Values = new huemul_DQRecord()
+    val Values = new huemul_DQRecord(huemulBigDataGov)
     Values.Table_Name =TableName
     Values.BBDD_Name =BBDDName
     Values.DF_Alias =AliasDF
@@ -604,7 +604,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     val duration = huemulBigDataGov.getDateTimeDiff(dt_start, dt_end)
     
-    val Values = new huemul_DQRecord()
+    val Values = new huemul_DQRecord(huemulBigDataGov)
     Values.Table_Name =TableName
     Values.BBDD_Name =BBDDName
     Values.DF_Alias =AliasDF
@@ -686,7 +686,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
     val duration = huemulBigDataGov.getDateTimeDiff(dt_start, dt_end)    
     
-    val Values = new huemul_DQRecord()
+    val Values = new huemul_DQRecord(huemulBigDataGov)
     Values.Table_Name =TableName
     Values.BBDD_Name =BBDDName
     Values.DF_Alias =AliasDF
@@ -854,7 +854,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         
         
         
-        val Values = new huemul_DQRecord()
+        val Values = new huemul_DQRecord(huemulBigDataGov)
         Values.Table_Name =dfTableName
         Values.BBDD_Name =dfDataBaseName
         Values.DF_Alias =AliasToQuery
@@ -954,6 +954,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         , DQ.BBDD_Name
         , DQ.DF_Alias
         , DQ.ColumnName
+        , DQ.DQ_Id
         , DQ.DQ_Name
         , DQ.DQ_Description
         , DQ.DQ_QueryLevel

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -820,6 +820,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
       //import java.util.Calendar;
       //Get DQ Result from DF
       
+      Control.NewStep(s"Step: DQ Result: Start analyzing the DQ result") 
       getDataQualitySentences(OfficialDataQuality, ManualRules).foreach { x =>
         x.NumRowsOK = FirstReg.getAs[Long](s"___DQ_${x.getId}")
         x.NumRowsTotal = if (x.getQueryLevel() == huemulType_DQQueryLevel.Aggregate) 1 else DQTotalRows
@@ -894,7 +895,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         //Save details to DF with errors
         if (dfTableName != null && huemulBigDataGov.GlobalSettings.DQ_SaveErrorDetails && IsError && x.getSaveErrorDetails()) {
           //Query to get detail errors
-          //Control.NewStep(s"Step: DQ Result: Get detales for (Id ${x.getId}) ${x.getDescription} ") 
+          Control.NewStep(s"Step: DQ Result: Get detail error for (Id ${x.getId}) ${x.getDescription}) ") 
           val SQL_Detail = DQ_GenQuery(AliasToQuery
                                       ,s"not (${x.getSQLFormula()})"
                                       ,!(x.getFieldName == null) //asField
@@ -906,6 +907,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                                       )
                                
           //Execute query
+          Control.NewStep(s"Step: DQ Result: Get detail error for (Id ${x.getId}) ${x.getDescription}, save to DF) ") 
           var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ", SQL_Detail)
                                
           if (DF_ErrorDetails == null)

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -882,7 +882,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
         Values.DQ_NumRowsError =DQWithError
         Values.DQ_NumRowsTotal =x.NumRowsTotal    
         Values.DQ_IsError = x.getNotification() == huemulType_DQNotification.ERROR && IsError //IsError 
-        Values.DQ_IsWarning = x.getNotification() == huemulType_DQNotification.WARNING && IsError
+        Values.DQ_IsWarning = (x.getNotification() == huemulType_DQNotification.WARNING || x.getNotification() == huemulType_DQNotification.WARNING_EXCLUDE) && IsError
         Values.DQ_duration_hour = duration.hour.toInt
         Values.DQ_duration_minute = duration.minute.toInt
         Values.DQ_duration_second = duration.second.toInt

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -914,10 +914,22 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
           Control.NewStep(s"Step: DQ Result: Get detail error for (Id ${x.getId}) ${x.getDescription}, save to DF) ") 
           var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ", SQL_Detail)
                                
-          if (DF_ErrorDetails == null)
-            DF_ErrorDetails = DF_EDetail
-          else
-            DF_ErrorDetails = DF_ErrorDetails.union(DF_EDetail)
+          if (dMaster == null) {
+            //acumulate DF, if call is outside huemul_Table
+            if (DF_ErrorDetails == null)
+              DF_ErrorDetails = DF_EDetail
+            else
+              DF_ErrorDetails = DF_ErrorDetails.union(DF_EDetail)
+          } else {
+            //if call is from huemul_Table, save detail to disk
+            //Save errors to disk
+            if (huemulBigDataGov.GlobalSettings.DQ_SaveErrorDetails && DF_EDetail != null && dMaster.getSaveDQResult) {
+              Control.NewStep("Start Save DQ Error Details ")                
+              if (!dMaster.savePersist_DQ(Control, DF_EDetail)){
+                huemulBigDataGov.logMessageWarn("Warning: DQ error can't save to disk")
+              }
+            }
+          }
         }
       }
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -130,8 +130,8 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
   /**   
    Create DF from SQL (equivalent to spark.sql method)
    */
-  def _CreateFinalQuery(Alias: String, sql: String, SaveInTemp: Boolean = true, NumPartitions: Integer = null, finalTable: huemul_Table) {
-    //WARNING: ANY CHANGE ON DF_from_SQL MUST BE REPLIATE IN THIS METHOD
+  def _CreateFinalQuery(Alias: String, sql: String, SaveInTemp: Boolean = true, NumPartitions: Integer = null, finalTable: huemul_Table, storageLevelOfDF: org.apache.spark.storage.StorageLevel) {
+    //WARNING: ANY CHANGE ON DF_from_SQL MUST BE REPLICATE IN THIS METHOD
     
     if (huemulBigDataGov.DebugMode && !huemulBigDataGov.HideLibQuery) huemulBigDataGov.logMessageDebug(sql)
     val dt_start = huemulBigDataGov.getCurrentDateTimeJava()
@@ -139,6 +139,10 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     val DFTemp = if (NumPartitions == null || NumPartitions <= 0) huemulBigDataGov.spark.sql(sql)
                  else huemulBigDataGov.spark.sql(sql).repartition(NumPartitions)
       
+    if (storageLevelOfDF != null) {
+      huemulBigDataGov.logMessageDebug(s"DF to ${storageLevelOfDF}")
+      DFTemp.persist(storageLevelOfDF)
+    }
     
     local_setDataFrame(DFTemp, Alias, SaveInTemp, false)
     val dt_end = huemulBigDataGov.getCurrentDateTimeJava()

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -789,6 +789,10 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
    Run DataQuality defined in Master
    */
   def DF_RunDataQuality(OfficialDataQuality: ArrayBuffer[huemul_DataQuality], ManualRules: ArrayBuffer[huemul_DataQuality], DF_to_Query: String, dMaster: huemul_Table): huemul_DataQualityResult = {
+    DF_RunDataQuality(OfficialDataQuality, ManualRules, DF_to_Query, dMaster, true)  
+  }
+  
+  def DF_RunDataQuality(OfficialDataQuality: ArrayBuffer[huemul_DataQuality], ManualRules: ArrayBuffer[huemul_DataQuality], DF_to_Query: String, dMaster: huemul_Table, registerDQOnce: Boolean ): huemul_DataQualityResult = {
     val AliasToQuery = if (DF_to_Query == null) this.AliasDF else DF_to_Query
      
     /*****************************************************************/
@@ -914,13 +918,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
           //Control.NewStep(s"Step: DQ Result: Get detail error for (Id ${x.getId}) ${x.getDescription}, save to DF) ") 
           var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ", SQL_Detail)
                                
-          if (dMaster == null) {
-            //acumulate DF, if call is outside huemul_Table
-            if (DF_ErrorDetails == null)
-              DF_ErrorDetails = DF_EDetail
-            else
-              DF_ErrorDetails = DF_ErrorDetails.union(DF_EDetail)
-          } else {
+          if (dMaster != null && !registerDQOnce) {
             //if call is from huemul_Table, save detail to disk
             //Save errors to disk
             if (huemulBigDataGov.GlobalSettings.DQ_SaveErrorDetails && DF_EDetail != null && dMaster.getSaveDQResult) {
@@ -929,6 +927,12 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                 huemulBigDataGov.logMessageWarn("Warning: DQ error can't save to disk")
               }
             }
+          } else {
+            //acumulate DF, if call is outside huemul_Table
+            if (DF_ErrorDetails == null)
+              DF_ErrorDetails = DF_EDetail
+            else
+              DF_ErrorDetails = DF_ErrorDetails.union(DF_EDetail)
           }
         }
       }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -482,7 +482,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
     try {
       DQResult.dqDF = huemulBigDataGov.spark.sql(SQL)
             
-      if (huemulBigDataGov.DebugMode) DQResult.dqDF.show()        
+      DQResult.dqDF.show()        
       huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_StatsByCol_${Col}",huemulBigDataGov.DebugMode, numPartitionsForTempFiles)
       
       val FirstRow = DQResult.dqDF.first()
@@ -530,8 +530,8 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
       
       if (huemulBigDataGov.DebugMode) {
         DQResult.dqDF.printSchema()
-        DQResult.dqDF.show()
       }
+      DQResult.dqDF.show()
       huemulBigDataGov.CreateTempTable(DQResult.dqDF,s"${AliasDF}_DQ_StatsByFunction_${function}",huemulBigDataGov.DebugMode, numPartitionsForTempFiles)
       
     } catch {

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -963,7 +963,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
                   ,dq_error_description: String
                   ): String = {
     return s"""SELECT '${Control.Control_Id }' as dq_control_id
-                                     ,'${dq_id }' as dq_error_id
+                                     ,'${dq_id }' as dq_dq_id
                                      ,'${if (haveField) fieldName else "all"}' as dq_error_columnname
                                      ,'${dq_error_notification}' as dq_error_notification 
                                      ,'${error_code}' as dq_error_code

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -113,6 +113,11 @@ class huemul_GlobalPath() extends Serializable {
       return s"${GetPath(huemulBigDataGov, TEMPORAL_Path)}$function_name/$table_name"
     }
     
+    //to save DF directly from DF without DataGovernance
+    def GetPathForSaveTableWithoutDG(huemulBigDataGov: huemul_BigDataGovernance,globalPath: ArrayBuffer[huemul_KeyValuePath], localPath_name: String, table_name: String): String = {        
+      return s"${GetPath(huemulBigDataGov, globalPath)}$localPath_name/$table_name"
+    }
+    
     
     def RaiseError(Environment: String) {
       sys.error(s"error, environment does't exist: '$Environment', must be '$GlobalEnvironments'  ")

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -67,7 +67,9 @@ class huemul_GlobalPath() extends Serializable {
     var MDM_SaveBackup: Boolean = true
     val MDM_Backup_Path: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
 
-    
+    //from 2.1
+    //set > 1 to cache hive metadata
+    var HIVE_HourToUpdateMetadata: Integer = 0
     
     /**
      Returns true if path has value, otherwise return false

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -1695,6 +1695,29 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
     return ExecResult             
   }
   
+  /**
+   * Get DQ details with dq_notification = WARNING_EXCLUDE and dq_iswarning = 1
+   */
+  def control_getDQResultForWarningExclude(): ArrayBuffer[String] = {
+    //Get Table Id
+    var result: ArrayBuffer[String] = new ArrayBuffer[String]()
+    
+    val ExecResultTable = huemulBigDataGov.CONTROL_connection.ExecuteJDBC_WithResult(s"""
+          select  dq_id
+          from control_dq
+          where processexec_id = ${ReplaceSQLStringNulls(this.Control_Id,null)}
+          AND   dq_notification = ${ReplaceSQLStringNulls("WARNING_EXCLUDE",null)}
+          AND   dq_iswarning = 1
+      """)
+    
+      
+    ExecResultTable.ResultSet.foreach { x =>  
+      result.append(x.getAs[String]("dq_id"))
+    }   
+    
+    return result
+  }
+  
   def control_getDQResult(): huemul_JDBCResult = {
     //Get Table Id
     val ExecResultTable = huemulBigDataGov.CONTROL_connection.ExecuteJDBC_WithResult(s"""

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -501,6 +501,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                              , BBDD_Name: String
                              , DF_Alias: String
                              , ColumnName: String
+                             , DQ_Id: String
                              , DQ_Name: String
                              , DQ_Description: String
                              , DQ_QueryLevel: huemulType_DQQueryLevel //DQ_IsAggregate: Boolean
@@ -521,11 +522,11 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                              , DQ_duration_second: Integer) {
                 
     //Create New Id
-    val DQId = huemulBigDataGov.huemul_GetUniqueId()
+    //val DQId = huemulBigDataGov.huemul_GetUniqueId() //version 2.1, issue 60
 
     if (huemulBigDataGov.RegisterInControl) {
       //Insert processExcec
-      control_DQ_add(   DQId
+      control_DQ_add(   DQ_Id //DQId
                          , Table_Name
                          , BBDD_Name
                          , this.Control_ClassName

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -36,6 +36,11 @@ class huemul_control_querycol extends Serializable {
 
 class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent: huemul_Control, runFrequency: huemulType_Frequency, IsSingleton: Boolean = true, RegisterInControlLog: Boolean = true) extends Serializable  {
   val huemulBigDataGov = phuemulBigDataGov
+  
+  private var _version_mayor: Int = 0
+  private var _version_minor: Int = 0
+  private var _version_patch: Int = 0
+  
   val Control_Id: String = huemulBigDataGov.huemul_GetUniqueId() 
   
   val Invoker = new Exception().getStackTrace()
@@ -65,11 +70,11 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
   private var control_QueryArray: ArrayBuffer[huemul_control_query] = new ArrayBuffer[huemul_control_query]()
   private var control_QueryColArray: ArrayBuffer[huemul_control_querycol] = new ArrayBuffer[huemul_control_querycol]()
   
+  
   //Find process name in control_process  
   if (RegisterInControlLog && huemulBigDataGov.RegisterInControl) {
     //new from 2.1: get version from control_config
-    control_getVersion()
-
+    control_SearchtVersion()
   
     control_process_addOrUpd(Control_ClassName
                   ,Control_ClassName
@@ -2132,7 +2137,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
     }
     
     val local_tablesuse_id = huemulBigDataGov.huemul_GetUniqueId()
-      
+      //println(s"getVersionFull: ${getVersionFull}")
     val ExecResult = huemulBigDataGov.CONTROL_connection.ExecuteJDBC_NoResulSet(s"""
           insert into control_tablesuse ( tablesuse_id
                                          ,table_id
@@ -2186,8 +2191,6 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
           		   ,${ReplaceSQLStringNulls(p_MDM_ProcessName,200)}
       )          		   
         """)
-    
-    
     return ExecResult             
   }
   
@@ -2195,7 +2198,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
    * New from 2.1
    * Used to get current version of control model
    */
-  private def control_getVersion() {
+  private def control_SearchtVersion() {
     try {
       val ExecResult = huemulBigDataGov.CONTROL_connection.ExecuteJDBC_WithResult(s"""
           SELECT version_mayor
@@ -2235,9 +2238,6 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
       huemulBigDataGov.logMessageInfo(s"control model version compatibility: ${getVersionFull()} ")
       
   }
-  private var _version_mayor: Int = 0
-  private var _version_minor: Int = 0
-  private var _version_patch: Int = 0
   
   def getVersionMayor(): Int = {return _version_mayor}
   def getVersionMinor(): Int = {return _version_minor}

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -735,6 +735,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                              ,null //DefMaster.NumRows_Updatable()
                              ,null //DefMaster.NumRows_NoChange() 
                              ,null //DefMaster.NumRows_Delete()
+                             ,null //DefMaster.numRows_Excluded()
                              ,null //DefMaster.NumRows_Total()
                              ,DefMaster.getPartitionValue
                              ,DefMaster._getBackupPath()
@@ -1037,6 +1038,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                              ,DefMaster.NumRows_Updatable()
                              ,DefMaster.NumRows_NoChange() 
                              ,DefMaster.NumRows_Delete()
+                             ,DefMaster.NumRows_Excluded()
                              ,DefMaster.NumRows_Total()
                              ,DefMaster.getPartitionValue
                              ,DefMaster._getBackupPath()
@@ -2103,6 +2105,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                              ,p_TableUse_numRowsUpdatable: java.lang.Long
                              ,p_TableUse_numRowsNoChange: java.lang.Long
                              ,p_TableUse_numRowsMarkDelete: java.lang.Long
+                             ,p_TableUse_numRowsExcluded: java.lang.Long
                              ,p_TableUse_numRowsTotal: java.lang.Long
                              ,p_TableUse_PartitionValue: String
                              ,p_Tableuse_pathbackup: String
@@ -2144,6 +2147,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                       								   ,tableuse_numrowsupdatable
                       								   ,tableuse_numrowsnochange 
                       								   ,tableuse_numrowsmarkdelete
+                                         ,tableuse_numrowsexcluded
                       								   ,tableuse_numrowstotal
                       								   ,tableuse_partitionvalue
                                          ,tableuse_pathbackup
@@ -2168,6 +2172,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
           		   ,${p_TableUse_numRowsUpdatable}
           		   ,${p_TableUse_numRowsNoChange}
           		   ,${p_TableUse_numRowsMarkDelete}
+          		   ,${p_TableUse_numRowsExcluded}
           		   ,${p_TableUse_numRowsTotal}
           		   ,${ReplaceSQLStringNulls(p_TableUse_PartitionValue,200)}
           		   ,${ReplaceSQLStringNulls(p_Tableuse_pathbackup,1000)}

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -1406,6 +1406,8 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                 						  ,processexec_param_min	
                 						  ,processexec_param_sec	
                 						  ,processexec_param_others
+                              ${if (getVersionFull() >= 20100) " ,processexec_huemulversion" else "" /* from 2.1: */}
+                              ${if (getVersionFull() >= 20100) " ,processexec_controlversion" else "" /* from 2.1: */}
                               ,error_id
                               ,mdm_fhcreate
                               ,mdm_processname)
@@ -1433,6 +1435,8 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
     			  ,${p_processExec_param_min}	
     			  ,${p_processExec_param_sec}	
     			  ,''
+            ${if (getVersionFull() >= 20100) s" ,${ReplaceSQLStringNulls(huemulBigDataGov.currentVersion ,20)}" else "" /* from 2.1: */}
+            ${if (getVersionFull() >= 20100) s" ,${ReplaceSQLStringNulls(s"${getVersionMayor()}.${getVersionMinor()}.${getVersionPatch()}" ,20)}" else "" /* from 2.1: */}
     			  ,null
     			  ,${ReplaceSQLStringNulls(huemulBigDataGov.getCurrentDateTime(),null)}
     			  ,${ReplaceSQLStringNulls(p_MDM_ProcessName,200)}

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -65,12 +65,12 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
   private var control_QueryArray: ArrayBuffer[huemul_control_query] = new ArrayBuffer[huemul_control_query]()
   private var control_QueryColArray: ArrayBuffer[huemul_control_querycol] = new ArrayBuffer[huemul_control_querycol]()
   
-  //new from 2.1: get version from control_config
-  control_getVersion()
-  
-  //Find process name in control_process
-  
+  //Find process name in control_process  
   if (RegisterInControlLog && huemulBigDataGov.RegisterInControl) {
+    //new from 2.1: get version from control_config
+    control_getVersion()
+
+  
     control_process_addOrUpd(Control_ClassName
                   ,Control_ClassName
                   ,Control_FileName

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -2149,7 +2149,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                       								   ,tableuse_numrowsupdatable
                       								   ,tableuse_numrowsnochange 
                       								   ,tableuse_numrowsmarkdelete
-                                         ,tableuse_numrowsexcluded
+                                         ${if (getVersionFull() >= 20100) " ,tableuse_numrowsexcluded" else "" /* from 2.1: */}
                       								   ,tableuse_numrowstotal
                       								   ,tableuse_partitionvalue
                                          ,tableuse_pathbackup
@@ -2174,7 +2174,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
           		   ,${p_TableUse_numRowsUpdatable}
           		   ,${p_TableUse_numRowsNoChange}
           		   ,${p_TableUse_numRowsMarkDelete}
-          		   ,${p_TableUse_numRowsExcluded}
+          		   ${if (getVersionFull() >= 20100) s",${p_TableUse_numRowsExcluded}" else "" /* from 2.1: */}
           		   ,${p_TableUse_numRowsTotal}
           		   ,${ReplaceSQLStringNulls(p_TableUse_PartitionValue,200)}
           		   ,${ReplaceSQLStringNulls(p_Tableuse_pathbackup,1000)}
@@ -2226,6 +2226,10 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
       case e: Exception => 
         huemulBigDataGov.logMessageError(s"control version error_ ${e}")
     }
+    
+    if (getVersionFull() > 0)
+      huemulBigDataGov.logMessageInfo(s"control model version compatibility: ${getVersionFull()} ")
+      
   }
   private var _version_mayor: Int = 0
   private var _version_minor: Int = 0

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -1435,8 +1435,8 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
     			  ,${p_processExec_param_min}	
     			  ,${p_processExec_param_sec}	
     			  ,''
-            ${if (getVersionFull() >= 20100) s" ,${ReplaceSQLStringNulls(huemulBigDataGov.currentVersion ,20)}" else "" /* from 2.1: */}
-            ${if (getVersionFull() >= 20100) s" ,${ReplaceSQLStringNulls(s"${getVersionMayor()}.${getVersionMinor()}.${getVersionPatch()}" ,20)}" else "" /* from 2.1: */}
+            ${if (getVersionFull() >= 20100) s" ,${ReplaceSQLStringNulls(huemulBigDataGov.currentVersion ,50)}" else "" /* from 2.1: */}
+            ${if (getVersionFull() >= 20100) s" ,${ReplaceSQLStringNulls(s"${getVersionMayor()}.${getVersionMinor()}.${getVersionPatch()}" ,50)}" else "" /* from 2.1: */}
     			  ,null
     			  ,${ReplaceSQLStringNulls(huemulBigDataGov.getCurrentDateTime(),null)}
     			  ,${ReplaceSQLStringNulls(p_MDM_ProcessName,200)}

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -1177,7 +1177,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
    */
   private def control_TestPlanTest_GetOK ( p_testPlan_Id: String): huemul_JDBCResult =  {
     var ExecResult = huemulBigDataGov.CONTROL_connection.ExecuteJDBC_WithResult(s"""
-                    select cast(count(1) as Integer) as cantidad, cast(sum(testplan_isok) as Integer) as total_ok 
+                    select count(1) as cantidad, sum(testplan_isok) as total_ok 
                     from control_testplan 
                     where testplangroup_id = '${p_testPlan_Id}' 
                     and testplan_name = 'TestPlan_IsOK'

--- a/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemulType_DQNotification.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemulType_DQNotification.scala
@@ -2,6 +2,6 @@ package com.huemulsolutions.bigdata.dataquality
 
 object huemulType_DQNotification extends Enumeration {
   type huemulType_DQNotification = Value
-  val ERROR, WARNING = Value
+  val ERROR, WARNING, WARNING_EXCLUDE = Value
 }
 

--- a/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemul_DQRecord.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemul_DQRecord.scala
@@ -1,14 +1,16 @@
 package com.huemulsolutions.bigdata.dataquality
 
 import org.apache.spark.sql.types._
+import com.huemulsolutions.bigdata.common.huemul_BigDataGovernance
 import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel._
 import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification._
 
-class huemul_DQRecord extends Serializable {
+class huemul_DQRecord(huemulBigDataGov: huemul_BigDataGovernance) extends Serializable {
   var Table_Name: String = null
   var BBDD_Name: String= null
   var DF_Alias: String= null
   var ColumnName: String= null
+  var DQ_Id: String = huemulBigDataGov.huemul_GetUniqueId()
   var DQ_Name: String= null
   var DQ_Description: String= null
   var DQ_QueryLevel: huemulType_DQQueryLevel = null

--- a/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemul_DataQuality.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemul_DataQuality.scala
@@ -30,6 +30,11 @@ class huemul_DataQuality(FieldName: huemul_Columns
   
   private var _DQ_ExternalCode: String = DQ_ExternalCode
   private var ToleranceError_Percent: Decimal = null
+  private var _QueryLevel: huemulType_DQQueryLevel = QueryLevel
+  private var _Notification: huemulType_DQNotification = Notification
+  private var _SaveErrorDetails: Boolean = SaveErrorDetails
+  
+  
   /**% of total for refuse validation. Example: 0.15 = 15% (null to not use)
    */
   def getToleranceError_Percent: Decimal = {return ToleranceError_Percent}
@@ -47,9 +52,7 @@ class huemul_DataQuality(FieldName: huemul_Columns
   def setId(Id: Integer) {_Id = Id}
   def getId(): Integer = {return _Id}
   
-  private var _QueryLevel: huemulType_DQQueryLevel = QueryLevel
-  private var _Notification: huemulType_DQNotification = Notification
-  private var _SaveErrorDetails: Boolean = SaveErrorDetails
+  
   
   
   def getFieldName(): huemul_Columns = {return FieldName}

--- a/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemul_DataQuality.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/dataquality/huemul_DataQuality.scala
@@ -47,11 +47,16 @@ class huemul_DataQuality(FieldName: huemul_Columns
   def setId(Id: Integer) {_Id = Id}
   def getId(): Integer = {return _Id}
   
+  private var _QueryLevel: huemulType_DQQueryLevel = QueryLevel
+  private var _Notification: huemulType_DQNotification = Notification
+  private var _SaveErrorDetails: Boolean = SaveErrorDetails
+  
+  
   def getFieldName(): huemul_Columns = {return FieldName}
-  def getQueryLevel(): huemulType_DQQueryLevel  = {return QueryLevel}
+  def getQueryLevel(): huemulType_DQQueryLevel  = {return _QueryLevel}
   def getDescription(): String  ={return  Description}
-  def getNotification(): huemulType_DQNotification = {return Notification}
-  def getSaveErrorDetails(): Boolean = {return if (QueryLevel == huemulType_DQQueryLevel.Row) SaveErrorDetails else false}
+  def getNotification(): huemulType_DQNotification = {return _Notification}
+  def getSaveErrorDetails(): Boolean = {return if (_QueryLevel == huemulType_DQQueryLevel.Row) _SaveErrorDetails else false}
   def getErrorCode(): Integer = {return Error_Code}
   def setDQ_ExternalCode(value: String) {_DQ_ExternalCode = value }
   def getDQ_ExternalCode(): String = {return _DQ_ExternalCode}
@@ -76,5 +81,22 @@ class huemul_DataQuality(FieldName: huemul_Columns
     ToleranceError_Rows = toleranceRows
     ToleranceError_Percent = tolerancePercent
   }
+  
+  def setQueryLevel(value: huemulType_DQQueryLevel): huemul_DataQuality = {
+    _QueryLevel = value
+    this
+  }
+  
+  def setNotification(value: huemulType_DQNotification ): huemul_DataQuality = {
+    _Notification = value
+    this
+  }
+  
+  def setSaveErrorDetails(value: Boolean): huemul_DataQuality = {
+    _SaveErrorDetails = value
+    this
+  }
+  
+  
  
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
@@ -23,77 +23,141 @@ class huemul_Columns(param_DataType: DataType
   def SetDefinitionIsClose() {DefinitionIsClose = true}
   
   
-  private var IsPK: Boolean = false
-  def getIsPK: Boolean = {return IsPK}
+  private var _IsPK: Boolean = false
+  def getIsPK: Boolean = {return _IsPK}
+  @deprecated("this method will be removed, instead use setIsPK(): huemul_Columns", "3.0")
   def setIsPK(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setIsPK, definition is close")
     else
-      IsPK = value
+      _IsPK = value
   }
   
-  private var IsUnique: Boolean = false
-  def getIsUnique: Boolean = {return IsUnique}
+  //2.1: return this
+  def setIsPK(): huemul_Columns = {
+    setIsPK(true)
+    this 
+  }
+  
+  private var _IsUnique: Boolean = false
+  private var _IsUnique_externalCode: String = "HUEMUL_DQ_003"
+  def getIsUnique_externalCode: String = {return if (_IsUnique_externalCode == null) "HUEMUL_DQ_003" else _IsUnique_externalCode}
+  def getIsUnique: Boolean = {return _IsUnique}
+  @deprecated("this method will be removed, instead use setIsUnique(externalCode: String = null): huemul_Columns", "3.0")
   def setIsUnique(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setIsUnique, definition is close")
     else
-      IsUnique = value
+      _IsUnique = value
   }
   
-  private var Nullable: Boolean = false
-  def getNullable: Boolean = {return Nullable}
+  //2.1: return this
+  def setIsUnique(externalCode: String = null): huemul_Columns = {
+    _IsUnique_externalCode = externalCode
+    setIsUnique(true)
+    this
+  }
+  
+  private var _Nullable: Boolean = false
+  private var _Nullable_externalCode: String = "HUEMUL_DQ_004"
+  def getNullable_externalCode: String = {return if (_Nullable_externalCode == null) "HUEMUL_DQ_004" else _Nullable_externalCode}
+  def getNullable: Boolean = {return _Nullable}
+  @deprecated("this method will be removed, instead use setNullable(externalCode: String = null): huemul_Columns", "3.0")
   def setNullable(value: Boolean) {
     if (DefinitionIsClose && value)
       sys.error("You can't change value of setNullable, definition is close")
     else
-      Nullable = value
+      _Nullable = value
   }
   
-  private var DefaultValue: String = "null"
-  def getDefaultValue: String = {return DefaultValue}
+  //2.1: return this
+  def setNullable(externalCode: String = null): huemul_Columns = {
+    _Nullable_externalCode = externalCode
+    setNullable(true)
+    this
+  }
+  
+  private var _DefaultValue: String = "null"
+  def getDefaultValue: String = {return _DefaultValue}
+  @deprecated("this method will be removed, instead use setDefaultValues(value: String): huemul_Columns", "3.0")
   def setDefaultValue(value: String) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDefaultValue, definition is close")
     else
-      DefaultValue = value
+      _DefaultValue = value
   }
+  
+  //2.1: return this
+  def setDefaultValues(value: String): huemul_Columns = {
+    setDefaultValue(value)
+    this
+  }
+  
   /** Secret, Restricted, Confidential, Intern, Departamental, Public   
    */
-  private var SecurityLevel: huemulType_SecurityLevel = huemulType_SecurityLevel.Public //Secret, Restricted, Confidential, Intern, Departamental, Public
-  def getSecurityLevel: huemulType_SecurityLevel = {return SecurityLevel}
+  private var _SecurityLevel: huemulType_SecurityLevel = huemulType_SecurityLevel.Public //Secret, Restricted, Confidential, Intern, Departamental, Public
+  def getSecurityLevel: huemulType_SecurityLevel = {return _SecurityLevel}
+  @deprecated("this method will be removed, instead use securityLevel(value: huemulType_SecurityLevel): huemul_Columns", "3.0")
   def setSecurityLevel(value: huemulType_SecurityLevel) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setSecurityLevel, definition is close")
     else
-      SecurityLevel = value
+      _SecurityLevel = value
   }
+  
+  //2.1: return this
+  /** Secret, Restricted, Confidential, Intern, Departamental, Public   
+   */
+  def securityLevel(value: huemulType_SecurityLevel): huemul_Columns = {
+    setSecurityLevel(value)
+    this
+  }
+  
   /** none, sha2   
    */
-  private var EncryptedType: String = "none" //none, sha2,
-  def getEncryptedType: String = {return EncryptedType}
+  private var _EncryptedType: String = "none" //none, sha2,
+  def getEncryptedType: String = {return _EncryptedType}
+  @deprecated("this method will be removed, instead use encryptedType(value: String): huemul_Columns", "3.0")
   def setEncryptedType(value: String) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setEncryptedType, definition is close")
     else
-      EncryptedType = value
+      _EncryptedType = value
+  }
+  
+  //2.1: return this
+  /** none, sha2   
+   */
+  def encryptedType(value: String): huemul_Columns = {
+    setEncryptedType(value)
+    this
   }
   
   /** set true for customers data that can be used for identify a unique customer (name, address, phone number)   
    */
-  private var ARCO_Data: Boolean = false
-  def getARCO_Data: Boolean = {return ARCO_Data}
+  private var arco_Data: Boolean = false
+  def getARCO_Data: Boolean = {return arco_Data}
+  @deprecated("this method will be removed, instead use setARCO_Data(): huemul_Columns", "3.0")
   def setARCO_Data(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setARCO_Data, definition is close")
     else
-      ARCO_Data = value
+      arco_Data = value
+  }
+  
+  //2.1: return this
+   /** set true for customers data that can be used for identify a unique customer (name, address, phone number)   
+   */
+  def setARCO_Data(): huemul_Columns = {
+    setARCO_Data(true)
+    this
   }
   
   /** associate an external id to link with business glossary concepts 
    */
   private var BusinessGlossary_Id: String = ""
   def getBusinessGlossary_Id: String = {return BusinessGlossary_Id}
+  @deprecated("this method will be removed, instead use setBusinessGlossary(value: String): huemul_Columns", "3.0")
   def setBusinessGlossary_Id(value: String) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setBusinessGlossary_Id, definition is close")
@@ -101,70 +165,143 @@ class huemul_Columns(param_DataType: DataType
       BusinessGlossary_Id = value
   }
   
-  private var DQ_MinLen: Integer = null
-  def getDQ_MinLen: Integer = {return DQ_MinLen}
+  //from 2.1
+  /** associate an external id to link with business glossary concepts 
+   */
+  def setBusinessGlossary(value: String): huemul_Columns = {
+    setBusinessGlossary_Id(value)
+    this
+  }
+  
+  private var _DQ_MinLen: Integer = null
+  private var _DQ_MinLen_externalCode: String = "HUEMUL_DQ_006"
+  def getDQ_MinLen_externalCode: String = {return if (_DQ_MinLen_externalCode == null) "HUEMUL_DQ_006" else _DQ_MinLen_externalCode}
+  def getDQ_MinLen: Integer = {return _DQ_MinLen}
+  @deprecated("this method will be removed, instead use setDQ_MinLen(value: Integer, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_MinLen(value: Integer) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_MinLen, definition is close")
     else
-      DQ_MinLen = value
+      _DQ_MinLen = value
   }
   
-  private var DQ_MaxLen: Integer = null
-  def getDQ_MaxLen: Integer = {return DQ_MaxLen}
+  //from 2.1
+  def setDQ_MinLen(value: Integer, externalCode: String = null): huemul_Columns = {
+    _DQ_MinLen_externalCode = externalCode
+    setDQ_MinLen(value)
+    this
+  }
+  
+  private var _DQ_MaxLen: Integer = null
+  private var _DQ_MaxLen_externalCode: String = "HUEMUL_DQ_006"
+  def getDQ_MaxLen_externalCode: String = {return if (_DQ_MaxLen_externalCode == null) "HUEMUL_DQ_006" else _DQ_MaxLen_externalCode}
+  def getDQ_MaxLen: Integer = {return _DQ_MaxLen}
+  @deprecated("this method will be removed, instead use setDQ_MaxLen(value: Integer, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_MaxLen(value: Integer) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_MaxLen, definition is close")
     else
-      DQ_MaxLen = value
+      _DQ_MaxLen = value
   }
   
-  private var DQ_MinDecimalValue: Decimal = null
-  def getDQ_MinDecimalValue: Decimal = {return DQ_MinDecimalValue}
+  //from 2.1
+  def setDQ_MaxLen(value: Integer, externalCode: String = null): huemul_Columns = {
+    _DQ_MaxLen_externalCode = externalCode
+    setDQ_MaxLen(value)
+    this
+  }
+  
+  private var _DQ_MinDecimalValue: Decimal = null
+  private var _DQ_MinDecimalValue_externalCode: String = "HUEMUL_DQ_007"
+  def getDQ_MinDecimalValue_externalCode: String = {return if (_DQ_MinDecimalValue_externalCode == null) "HUEMUL_DQ_007" else _DQ_MinDecimalValue_externalCode}
+  def getDQ_MinDecimalValue: Decimal = {return _DQ_MinDecimalValue}
+  @deprecated("this method will be removed, instead use setDQ_MinDecimalValue(value: Decimal, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_MinDecimalValue(value: Decimal) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_MinDecimalValue, definition is close")
     else
-      DQ_MinDecimalValue = value
+      _DQ_MinDecimalValue = value
   }
   
-  private var DQ_MaxDecimalValue: Decimal = null
-  def getDQ_MaxDecimalValue: Decimal = {return DQ_MaxDecimalValue}
+  //from 2.1
+  def setDQ_MinDecimalValue(value: Decimal, externalCode: String = null): huemul_Columns = {
+    _DQ_MinDecimalValue_externalCode = externalCode
+    setDQ_MinDecimalValue(value)
+    this
+  }
+  
+  private var _DQ_MaxDecimalValue: Decimal = null
+  private var _DQ_MaxDecimalValue_externalCode: String = "HUEMUL_DQ_007"
+  def getDQ_MaxDecimalValue_externalCode: String = {return if (_DQ_MaxDecimalValue_externalCode == null) "HUEMUL_DQ_007" else _DQ_MaxDecimalValue_externalCode}
+  def getDQ_MaxDecimalValue: Decimal = {return _DQ_MaxDecimalValue}
+  @deprecated("this method will be removed, instead use setDQ_MaxDecimalValue(value: Decimal, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_MaxDecimalValue(value: Decimal) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_MaxDecimalValue, definition is close")
     else
-      DQ_MaxDecimalValue = value
+      _DQ_MaxDecimalValue = value
+  }
+  
+  //from 2.1
+  def setDQ_MaxDecimalValue(value: Decimal, externalCode: String = null): huemul_Columns = {
+    _DQ_MaxDecimalValue_externalCode = externalCode
+    setDQ_MaxDecimalValue(value)
+    this
   }
   
   /**Format: YYYY-MM-DD HH:mm:ss or fieldName   
    */
-  private var DQ_MinDateTimeValue: String = null
-  def getDQ_MinDateTimeValue: String = {return DQ_MinDateTimeValue}
+  private var _DQ_MinDateTimeValue: String = null
+  private var _DQ_MinDateTimeValue_externalCode: String = "HUEMUL_DQ_008"
+  def getDQ_MinDateTimeValue_externalCode: String = {return if (_DQ_MinDateTimeValue_externalCode==null) "HUEMUL_DQ_008" else _DQ_MinDateTimeValue_externalCode}
+  def getDQ_MinDateTimeValue: String = {return _DQ_MinDateTimeValue}
+  @deprecated("this method will be removed, instead use setDQ_MinDateTimeValue(value: String, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_MinDateTimeValue(value: String) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_MinDateTimeValue, definition is close")
     else
-      DQ_MinDateTimeValue = value
+      _DQ_MinDateTimeValue = value
+  }
+  
+  //from 2.1
+  /**Format: YYYY-MM-DD HH:mm:ss or fieldName   
+   */
+  def setDQ_MinDateTimeValue(value: String, externalCode: String = null): huemul_Columns = {
+    _DQ_MinDateTimeValue_externalCode = externalCode
+    setDQ_MinDateTimeValue(value)
+    this
   }
   
   /**Format: YYYY-MM-DD HH:mm:ss or fieldName   
    */
-  private var DQ_MaxDateTimeValue: String = null
-  def getDQ_MaxDateTimeValue: String = {return DQ_MaxDateTimeValue}
+  private var _DQ_MaxDateTimeValue: String = null
+  private var _DQ_MaxDateTimeValue_externalCode: String = "HUEMUL_DQ_008"
+  def getDQ_MaxDateTimeValue_externalCode: String = {return if (_DQ_MaxDateTimeValue_externalCode==null) "HUEMUL_DQ_008" else _DQ_MaxDateTimeValue_externalCode}
+  def getDQ_MaxDateTimeValue: String = {return _DQ_MaxDateTimeValue}
+  @deprecated("this method will be removed, instead use setDQ_MaxDateTimeValue(value: String, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_MaxDateTimeValue(value: String) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_MaxDateTimeValue, definition is close")
     else
-      DQ_MaxDateTimeValue = value
+      _DQ_MaxDateTimeValue = value
+  }
+  
+  //from 2.1
+  /**Format: YYYY-MM-DD HH:mm:ss or fieldName   
+   */
+  def setDQ_MaxDateTimeValue(value: String, externalCode: String = null): huemul_Columns = {
+    _DQ_MaxDateTimeValue_externalCode = externalCode
+    setDQ_MaxDateTimeValue(value)
+    this
   }
   
    /** Validate Regular Expression
    */
-  private var DQ_RegExp: String = null //none, sha2,
-  private var DQ_RegExp_externalCode: String = null
+  private var DQ_RegExp: String = null 
+  private var DQ_RegExp_externalCode: String = "HUEMUL_DQ_005"
   def getDQ_RegExp: String = {return DQ_RegExp}
-  def getDQ_RegExp_externalCode: String = {return DQ_RegExp_externalCode}
+  def getDQ_RegExp_externalCode: String = {return if (DQ_RegExp_externalCode == null) "HUEMUL_DQ_005" else DQ_RegExp_externalCode}
+  @deprecated("this method will be removed, instead use setDQ_RegExpresion(value: String, externalCode: String = null): huemul_Columns", "3.0")
   def setDQ_RegExp(value: String, dq_externalCode: String = null) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setDQ_RegExp, definition is close")
@@ -174,52 +311,101 @@ class huemul_Columns(param_DataType: DataType
     }
   }
   
+  //from 2.1
+  /** Validate Regular Expression
+   */
+  def setDQ_RegExpresion(value: String, externalCode: String = null): huemul_Columns = {
+    setDQ_RegExp(value, externalCode)
+    this
+  }
+  
   /**
    save all old values trace in other table
    */
-  private var MDM_EnableOldValue_FullTrace: Boolean = false
-  def getMDM_EnableOldValue_FullTrace: Boolean = {return MDM_EnableOldValue_FullTrace}
+  private var _MDM_EnableOldValue_FullTrace: Boolean = false
+  def getMDM_EnableOldValue_FullTrace: Boolean = {return _MDM_EnableOldValue_FullTrace}
+  @deprecated("this method will be removed, instead use setMDM_EnableOldValue_FullTrace(): huemul_Columns", "3.0")
   def setMDM_EnableOldValue_FullTrace(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setMDM_EnableOldValue_FullTrace, definition is close")
     else
-      MDM_EnableOldValue_FullTrace = value
+      _MDM_EnableOldValue_FullTrace = value
+  }
+  
+  //from 2.1
+  /**
+   save all old values trace in other table
+   */
+  def setMDM_EnableOldValue_FullTrace(): huemul_Columns = {
+    setMDM_EnableOldValue_FullTrace(true)
+    this
   }
   
   /**
    save old value when new value arrive 
    */
-  private var MDM_EnableOldValue: Boolean = false
-  def getMDM_EnableOldValue: Boolean = {return MDM_EnableOldValue}
+  private var _MDM_EnableOldValue: Boolean = false
+  def getMDM_EnableOldValue: Boolean = {return _MDM_EnableOldValue}
+  @deprecated("this method will be removed, instead use setMDM_EnableOldValue(): huemul_Columns", "3.0")
   def setMDM_EnableOldValue(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setMDM_EnableOldValue, definition is close")
     else
-      MDM_EnableOldValue = value
+      _MDM_EnableOldValue = value
   }
+  
+  //from 2.1
+  /**
+   save old value when new value arrive 
+   */
+  def setMDM_EnableOldValue(): huemul_Columns = {
+    setMDM_EnableOldValue(true)
+    this
+  }
+  
   /**
    create a new field with datetime log for change value
    */
-  private var MDM_EnableDTLog: Boolean = false
-  def getMDM_EnableDTLog: Boolean = {return MDM_EnableDTLog}
+  private var _MDM_EnableDTLog: Boolean = false
+  def getMDM_EnableDTLog: Boolean = {return _MDM_EnableDTLog}
+  @deprecated("this method will be removed, instead use setMDM_EnableDTLog(): huemul_Columns", "3.0")
   def setMDM_EnableDTLog(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setMDM_EnableDTLog, definition is close")
     else
-      MDM_EnableDTLog = value
+      _MDM_EnableDTLog = value
+  }
+  
+  //from 2.1
+  /**
+   create a new field with datetime log for change value
+   */
+  def setMDM_EnableDTLog(): huemul_Columns = {
+    setMDM_EnableDTLog(true)
+    this
   }
   
   /**
    create a new field with Process Log for change value
    */
-  private var MDM_EnableProcessLog: Boolean = false
-  def getMDM_EnableProcessLog: Boolean = {return MDM_EnableProcessLog}
+  private var _MDM_EnableProcessLog: Boolean = false
+  def getMDM_EnableProcessLog: Boolean = {return _MDM_EnableProcessLog}
+  @deprecated("this method will be removed, instead use setMDM_EnableProcessLog(): huemul_Columns", "3.0")
   def setMDM_EnableProcessLog(value: Boolean) {
     if (DefinitionIsClose)
       sys.error("You can't change value of setMDM_EnableProcessLog, definition is close")
     else
-      MDM_EnableProcessLog = value
+      _MDM_EnableProcessLog = value
   }  
+  
+  //from 2.1
+  /**
+   create a new field with Process Log for change value
+   */
+  def setMDM_EnableProcessLog(): huemul_Columns = {
+    setMDM_EnableProcessLog(true)
+    this
+  }
    
   
   //user mapping attributes

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1673,6 +1673,15 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       val dt_start = huemulBigDataGov.getCurrentDateTimeJava()
       val DF_Left = huemulBigDataGov.DF_ExecuteQuery(AliasDistinct, SQLLeft)
       val TotalLeft = DF_Left.count()
+      
+      if (TotalLeft > 0) {
+        Result.isError = true
+        Result.Description = s"huemul_Table Error: Foreing Key DQ Error, ${TotalLeft} records not found"
+        Result.Error_Code = 1024
+        Result.dqDF = DF_Left
+        Result.profilingResult.count_all_Col = TotalLeft
+        DF_Left.show()
+      }
          
       val NumTotalDistinct = DF_Distinct.count()
       val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
@@ -1706,12 +1715,6 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       
       //Step3: Return DQ Validation
       if (TotalLeft > 0) {
-        Result.isError = true
-        Result.Description = s"huemul_Table Error: Foreing Key DQ Error, ${TotalLeft} records not found"
-        Result.Error_Code = 1024
-        Result.dqDF = DF_Left
-        Result.profilingResult.count_all_Col = TotalLeft
-        DF_Left.show()
         
         //get SQL to save error details to DQ_Error_Table
         val SQL_ErrorDetail = this.DataFramehuemul.DQ_GenQuery( AliasDistinct   //sqlfrom

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2348,7 +2348,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       this._NumRows_Updatable = 0
       this._NumRows_Delete = 0
       this._NumRows_NoChange = 0
-      this._NumRows_Excluded = 0
+      //this._NumRows_Excluded = 0
     } else {
       //DQ for Reference and Master Data
       val DQ_ReferenceData: DataFrame = huemulBigDataGov.spark.sql(
@@ -2507,6 +2507,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     if (!this.DefinitionIsClose)
       this.raiseError(s"huemul_Table Error: MUST call ApplyTableDefinition ${this.TableName}", 1048)
     
+    _NumRows_Excluded = 0  
+      
     var LocalControl = new huemul_Control(huemulBigDataGov, Control ,huemulType_Frequency.ANY_MOMENT, false )
     LocalControl.AddParamInformation("AliasNewData", AliasNewData)
     LocalControl.AddParamInformation("IsInsert", IsInsert.toString())

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1893,10 +1893,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                                                                    GROUP BY ${SQL_PK}
                                                                                    HAVING COUNT(1) > 1
                                                                                 """)
-        df_detail_01.cache()
+        val numReg_01 = df_detail_01.count()
         //get rows duplicated
-        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step2)")
-        val df_detail_02 = huemulBigDataGov.DF_ExecuteQuery("___temp_pk_det_02", s""" SELECT PK.*
+        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step2, $numReg_01 duplicated)")
+        val df_detail_02 = huemulBigDataGov.DF_ExecuteQuery("___temp_pk_det_02", s""" SELECT ${if (numReg_01 < 1000000) "/*+ BROADCAST(dup) */ " else "" } PK.*
                                                                                    FROM ${this.DataFramehuemul.Alias} PK
                                                                                      INNER JOIN ___temp_pk_det_01 dup
                                                                                         ON ${SQL_PK_on}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -522,7 +522,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //Nombre de DQ      
       if (x.get(this).isInstanceOf[huemul_DataQuality]) {
         val DQField = x.get(this).asInstanceOf[huemul_DataQuality]
-        DQField.setMyName(x.getName)       
+        DQField.setMyName(x.getName)     
+        
+        if (DQField.getNotification() == huemulType_DQNotification.WARNING_EXCLUDE && DQField.getSaveErrorDetails() == false)
+          raiseError(s"huemul_Table Error: DQ ${x.getName}:, Notification is set to WARNING_EXCLUDE, but SaveErrorDetails is set to false. Use setSaveErrorDetails to set true ",1055)
+          
       }
       
       //Nombre de FK
@@ -542,7 +546,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"HuemulControl: end ApplyTableDefinition")
     if (!HasPK) this.raiseError("huemul_Table Error: PK not defined", 1017)
     if (this.getTableType == huemulType_Tables.Transaction && !PartitionFieldValid)
-      raiseError(s"huemul_Table Error: PartitionField should be defined if TableType is Transactional (invalida name ${this.getPartitionField} )",1035)
+      raiseError(s"huemul_Table Error: PartitionField should be defined if TableType is Transactional (invalid name ${this.getPartitionField} )",1035)
       
     DefinitionIsClose = true
     return true

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1741,7 +1741,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     return Result
   }
   
-  private def DF_DataQualityMasterAuto(IsSelectiveUpdate: Boolean): huemul_DataQualityResult = {
+  private def DF_DataQualityMasterAuto(IsSelectiveUpdate: Boolean, LocalControl: huemul_Control): huemul_DataQualityResult = {
     var Result: huemul_DataQualityResult = new huemul_DataQualityResult()
     val ArrayDQ: ArrayBuffer[huemul_DataQuality] = new ArrayBuffer[huemul_DataQuality]()
     
@@ -1882,6 +1882,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
             SQL_PK_on = s"${SQL_PK_on} PK.${x_cols.get_MyName()} = dup.${x_cols.get_MyName()} "
         }    
         
+        
+        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step1)")
         //PK error found, get PK duplicated
         val df_detail_01 = huemulBigDataGov.DF_ExecuteQuery("___temp_pk_det_01", s""" SELECT ${SQL_PK}, COUNT(1) as Cantidad
                                                                                    FROM ${this.DataFramehuemul.Alias}
@@ -1890,6 +1892,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                                                                 """)
         df_detail_01.cache()
         //get rows duplicated
+        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step2)")
         val df_detail_02 = huemulBigDataGov.DF_ExecuteQuery("___temp_pk_det_02", s""" SELECT PK.*
                                                                                    FROM ${this.DataFramehuemul.Alias} PK
                                                                                      INNER JOIN ___temp_pk_det_01 dup
@@ -1909,6 +1912,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                                           )
                              
         //Execute query
+        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (save to disk)")
         var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ_PK", SQL_Detail)
                              
         if (ResultDQ.DetailErrorsDF == null)
@@ -2441,7 +2445,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   
       //DataQuality by Columns
       LocalControl.NewStep("Start DataQuality")
-      val DQResult = DF_DataQualityMasterAuto(IsSelectiveUpdate)
+      val DQResult = DF_DataQualityMasterAuto(IsSelectiveUpdate, LocalControl)
       //Foreing Keys by Columns
       LocalControl.NewStep("Start ForeingKey ")
       val FKResult = DF_ForeingKeyMasterAuto()

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2070,7 +2070,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
 
      
       //STEP 2: Execute final table  //Add this.getNumPartitions param in v1.3
-      DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this)
+      DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this, storageLevelOfDF)
       if (huemulBigDataGov.DebugMode) this.DataFramehuemul.DataFrame.show()
         
       //Unpersist first DF
@@ -2099,7 +2099,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       if (huemulBigDataGov.DebugMode && !huemulBigDataGov.HideLibQuery)
         huemulBigDataGov.logMessageDebug(SQLFinalTable)
       //STEP 2: Execute final table //Add debugmode and getnumpartitions in v1.3
-      DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this)
+      DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this, storageLevelOfDF)
       
       LocalControl.NewStep("Transaction: Get Statistics info")
       this._NumRows_Total = this.DataFramehuemul.getNumRows
@@ -2234,7 +2234,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
 
      
       //STEP 2: Execute final table // Add debugmode and getnumpartitions in v1.3 
-      DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this)
+      DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this, storageLevelOfDF)
       if (huemulBigDataGov.DebugMode) this.DataFramehuemul.DataFrame.show()
       
       
@@ -2260,13 +2260,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     } else
       raiseError(s"huemul_Table Error: ${_TableType} found, Master o Reference required ", 1007)
       
-    //if (this._NumRows_Total < 1000000)
-    if (storageLevelOfDF != null) {
-      //huemulBigDataGov.logMessageInfo("***** cache")
-      this.DataFramehuemul.DataFrame.persist(storageLevelOfDF)
-      }
-    //else 
-      //huemulBigDataGov.logMessageInfo("***** sin cache")
+    
+    
   }
   
   private def UpdateStatistics(LocalControl: huemul_Control, TypeOfCall: String, Alias: String) {

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -383,6 +383,22 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     return internalGetTable(huemulType_InternalTableType.Normal)
   }
   
+  //new from 2.1
+  /**
+   * Return DataBaseName.TableName for DQ
+   */
+  def getTable_DQ(): String = {
+    return internalGetTable(huemulType_InternalTableType.DQ)
+  }
+  
+  //new from 2.1
+  /**
+   * Return DataBaseName.TableName for OldValueTrace
+   */
+  def getTable_OldValueTrace(): String = {
+    return internalGetTable(huemulType_InternalTableType.OldValueTrace)
+  }
+  
   
   private def internalGetTable(internalTableType: huemulType_InternalTableType, withDataBase: Boolean = true): String = {
     var _getTable: String = ""

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1901,7 +1901,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                                                                      INNER JOIN ___temp_pk_det_01 dup
                                                                                         ON ${SQL_PK_on}
                                                                                 """)   
-
+        val numReg = df_detail_02.count()                                                                                 
                                                                               
         val DQ_Id_PK = ResultDQ.getDQResult().filter { dqres => dqres.DQ_ErrorCode == 1018 }(0).DQ_Id
         val SQL_Detail = this.DataFramehuemul.DQ_GenQuery( "___temp_pk_det_02"   //sqlfrom
@@ -1911,11 +1911,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                                           , DQ_Id_PK
                                                           , huemulType_DQNotification.ERROR //dq_error_notification 
                                                           , 1018 //error_code
-                                                          , s"(1018) PK ERROR ON ${SQL_PK_on}"// dq_error_description
+                                                          , s"(1018) PK ERROR ON ${SQL_PK_on} ($numReg reg)"// dq_error_description
                                                           )
                              
         //Execute query
-        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (save to disk)")
+        LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step3, $numReg rows)")
         var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ_PK", SQL_Detail)
                              
         if (ResultDQ.DetailErrorsDF == null)

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -63,7 +63,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   private var _TableType : huemulType_Tables = huemulType_Tables.Transaction
   
   private var _PK_externalCode: String = "HUEMUL_DQ_002"
-  def getPK_externalCode: String = {return _PK_externalCode}
+  def getPK_externalCode: String = {return if (_PK_externalCode==null) "HUEMUL_DQ_002" else _PK_externalCode }
   def setPK_externalCode(value: String) {
     _PK_externalCode = value  
   }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -62,7 +62,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   def getTableType: huemulType_Tables = {return _TableType}
   private var _TableType : huemulType_Tables = huemulType_Tables.Transaction
   
-  
+  private var _PK_externalCode: String = "HUEMUL_DQ_002"
+  def getPK_externalCode: String = {return _PK_externalCode}
+  def setPK_externalCode(value: String) {
+    _PK_externalCode = value  
+  }
   /**
    Save DQ Result to disk, only if DQ_SaveErrorDetails in GlobalPath is true
    */
@@ -1854,7 +1858,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     }  
     
     if (!warning_exclude) { 
-      val DQ_PK : huemul_DataQuality = new huemul_DataQuality(null, s"PK Validation",s"count(1) = count(distinct ${SQL_PK} )", 1018, huemulType_DQQueryLevel.Aggregate,huemulType_DQNotification.ERROR, true, "HUEMUL_DQ_002" )
+      val DQ_PK : huemul_DataQuality = new huemul_DataQuality(null, s"PK Validation",s"count(1) = count(distinct ${SQL_PK} )", 1018, huemulType_DQQueryLevel.Aggregate,huemulType_DQNotification.ERROR, true, getPK_externalCode )
       DQ_PK.setTolerance(0, null)
       ArrayDQ.append(DQ_PK)    
      
@@ -1864,7 +1868,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       SQL_Unique_FinalTable().foreach { x => 
         if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"DF_SAVE DQ: VALIDATE UNIQUE FOR FIELD $x")
         
-        val DQ_UNIQUE : huemul_DataQuality = new huemul_DataQuality(x, s"UNIQUE Validation ",s"count(1) = count(distinct ${x.get_MyName()} )", 2006, huemulType_DQQueryLevel.Aggregate,huemulType_DQNotification.ERROR, true, "HUEMUL_DQ_003" )
+        val DQ_UNIQUE : huemul_DataQuality = new huemul_DataQuality(x, s"UNIQUE Validation ",s"count(1) = count(distinct ${x.get_MyName()} )", 2006, huemulType_DQQueryLevel.Aggregate,huemulType_DQNotification.ERROR, true, x.getIsUnique_externalCode )
         DQ_UNIQUE.setTolerance(0, null)
         ArrayDQ.append(DQ_UNIQUE) 
       }
@@ -1875,7 +1879,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     SQL_NotNull_FinalTable(warning_exclude).foreach { x => 
       if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"DF_SAVE DQ: VALIDATE NOT NULL FOR FIELD ${x.get_MyName()}")
       
-        val NotNullDQ : huemul_DataQuality = new huemul_DataQuality(x, s"Not Null for field ${x.get_MyName()} ", s"${x.get_MyName()} IS NOT NULL",1023, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, "HUEMUL_DQ_004")
+        val NotNullDQ : huemul_DataQuality = new huemul_DataQuality(x, s"Not Null for field ${x.get_MyName()} ", s"${x.get_MyName()} IS NOT NULL",1023, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, x.getNullable_externalCode)
         NotNullDQ.setTolerance(0, null)
         ArrayDQ.append(NotNullDQ)
     }
@@ -1887,7 +1891,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         var tand = ""
                   
         SQLFormula = s" (${SQLFormula}) or (${x.get_MyName()} is null) "
-        val RegExp : huemul_DataQuality = new huemul_DataQuality(x, s"RegExp Column ${x.get_MyName()}",SQLFormula, 1041, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, if (x.getDQ_RegExp_externalCode == null) "HUEMUL_DQ_005" else x.getDQ_RegExp_externalCode  )
+        val RegExp : huemul_DataQuality = new huemul_DataQuality(x, s"RegExp Column ${x.get_MyName()}",SQLFormula, 1041, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, x.getDQ_RegExp_externalCode  )
         
         RegExp.setTolerance(0, null)
         ArrayDQ.append(RegExp)
@@ -1908,7 +1912,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           SQLFormula += s" $tand length(${x.get_MyName()}) <= ${x.getDQ_MaxLen}"
                   
         SQLFormula = s" (${SQLFormula}) or (${x.get_MyName()} is null) "
-        val MinMaxLen : huemul_DataQuality = new huemul_DataQuality(x, s"length DQ for Column ${x.get_MyName()}",SQLFormula, 1020, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, "HUEMUL_DQ_006" )
+        val MinMaxLen : huemul_DataQuality = new huemul_DataQuality(x, s"length DQ for Column ${x.get_MyName()}",SQLFormula, 1020, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, if (x.getDQ_MinLen_externalCode == null) x.getDQ_MaxLen_externalCode else x.getDQ_MinLen_externalCode )
         MinMaxLen.setTolerance(0, null)
         ArrayDQ.append(MinMaxLen)
     }
@@ -1927,7 +1931,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           SQLFormula += s" $tand ${x.get_MyName()} <= ${x.getDQ_MaxDecimalValue}"
         
         SQLFormula = s" (${SQLFormula}) or (${x.get_MyName()} is null) "
-        val MinMaxNumber : huemul_DataQuality = new huemul_DataQuality(x, s"Number range DQ for Column ${x.get_MyName()}", SQLFormula,1021, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true,"HUEMUL_DQ_007")
+        val MinMaxNumber : huemul_DataQuality = new huemul_DataQuality(x, s"Number range DQ for Column ${x.get_MyName()}", SQLFormula,1021, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true,if (x.getDQ_MinDecimalValue_externalCode == null) x.getDQ_MaxDecimalValue_externalCode else x.getDQ_MinDecimalValue_externalCode)
         MinMaxNumber.setTolerance(0, null)         
         ArrayDQ.append(MinMaxNumber)
     }
@@ -1946,7 +1950,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           SQLFormula += s" $tand ${x.get_MyName()} <= '${x.getDQ_MaxDateTimeValue}'"
           
         SQLFormula = s" (${SQLFormula}) or (${x.get_MyName()} is null) "
-        val MinMaxDT : huemul_DataQuality = new huemul_DataQuality(x, s"DateTime range DQ Column ${x.get_MyName()} ", SQLFormula, 1022, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, "HUEMUL_DQ_008")
+        val MinMaxDT : huemul_DataQuality = new huemul_DataQuality(x, s"DateTime range DQ Column ${x.get_MyName()} ", SQLFormula, 1022, huemulType_DQQueryLevel.Row,huemulType_DQNotification.ERROR, true, if (x.getDQ_MinDateTimeValue_externalCode == null) x.getDQ_MaxDateTimeValue_externalCode else x.getDQ_MinDateTimeValue_externalCode)
         MinMaxDT.setTolerance(0, null)
         ArrayDQ.append(MinMaxDT)
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2759,7 +2759,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   /**
    * Save DQ Result data to disk
    */
-  private def savePersist_DQ(LocalControl: huemul_Control, DF: DataFrame): Boolean = {
+  def savePersist_DQ(LocalControl: huemul_Control, DF: DataFrame): Boolean = {
     var DF_Final = DF
     var Result: Boolean = true
     this._table_dq_isused = 1

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1774,7 +1774,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       Values.DQ_NumRowsTotal =numTotal
       Values.DQ_IsError = if (x.getNotification() == huemulType_DQNotification.ERROR) Result.isError else false
       Values.DQ_IsWarning = if (x.getNotification() != huemulType_DQNotification.ERROR) Result.isError else false
-      Values.DQ_ExternalCode = "HUEMUL_DQ_001"
+      Values.DQ_ExternalCode = x.getExternalCode // "HUEMUL_DQ_001"
       Values.DQ_duration_hour = duration.hour.toInt
       Values.DQ_duration_minute = duration.minute.toInt
       Values.DQ_duration_second = duration.second.toInt

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1708,7 +1708,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       val dt_end = huemulBigDataGov.getCurrentDateTimeJava()
       val duration = huemulBigDataGov.getDateTimeDiff(dt_start, dt_end)
       
-      val Values = new huemul_DQRecord()
+      val Values = new huemul_DQRecord(huemulBigDataGov)
       Values.Table_Name =TableName
       Values.BBDD_Name =DataBaseName
       Values.DF_Alias = DataFramehuemul.Alias

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.types._
 
 class huemul_TableDQ extends Serializable  {
   val dq_control_id = new huemul_Columns (StringType, false, "DQ Id partition (control_id)", false)
+  val dq_error_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false)
   val dq_error_columnname = new huemul_Columns (StringType, false, "DQ Column Name ", false)
   val dq_error_notification = new huemul_Columns (StringType, false, "DQ Notification", false)
   val dq_error_code = new huemul_Columns (StringType, false, "DQ Error Code", false)

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.types._
 
 class huemul_TableDQ extends Serializable  {
   val dq_control_id = new huemul_Columns (StringType, false, "DQ Id partition (control_id)", false)
-  val dq_error_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false)
+  val dq_dq_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false)
   val dq_error_columnname = new huemul_Columns (StringType, false, "DQ Column Name ", false)
   val dq_error_notification = new huemul_Columns (StringType, false, "DQ Notification", false)
   val dq_error_code = new huemul_Columns (StringType, false, "DQ Error Code", false)

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table_Relationship.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table_Relationship.scala
@@ -2,6 +2,8 @@ package com.huemulsolutions.bigdata.tables
 
 import scala.collection.mutable.ArrayBuffer
 import com.huemulsolutions.bigdata.common.huemul_BigDataGovernance
+import com.huemulsolutions.bigdata.dataquality._
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification.huemulType_DQNotification
 
 class huemul_Table_RelationshipColumns (pk: huemul_Columns, fk: huemul_Columns) {
   var PK: huemul_Columns = pk
@@ -16,6 +18,20 @@ class huemul_Table_Relationship(Class_TableName: Object, allowNull: Boolean) {
       Relationship.append(new huemul_Table_RelationshipColumns(PK, FK) )
   }
   val _Class_TableName: Object = Class_TableName
+ 
+  private var _Notification: com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification.huemulType_DQNotification = huemulType_DQNotification.ERROR
+  def setNotification(value: huemulType_DQNotification ): huemul_Table_Relationship = {
+    _Notification = value
+    this
+  } 
+  def getNotification(): huemulType_DQNotification = {return _Notification}
   
+  //From 2.1 --> apply broadcast
+  private var _BroadcastJoin: Boolean = false
+  def broadcastJoin(value: Boolean ): huemul_Table_Relationship = {
+    _BroadcastJoin = value
+    this
+  } 
+  def getBroadcastJoin(): Boolean = {return _BroadcastJoin}
   
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table_Relationship.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table_Relationship.scala
@@ -36,8 +36,9 @@ class huemul_Table_Relationship(Class_TableName: Object, allowNull: Boolean) {
   
   private var _externalCode: String = "HUEMUL_DQ_001"
   def getExternalCode: String = {return if (_externalCode==null) "HUEMUL_DQ_001" else _externalCode }
-  def setExternalCode(value: String) {
+  def setExternalCode(value: String): huemul_Table_Relationship = {
     _externalCode = value  
+    return this
   }
   
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table_Relationship.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table_Relationship.scala
@@ -34,4 +34,10 @@ class huemul_Table_Relationship(Class_TableName: Object, allowNull: Boolean) {
   } 
   def getBroadcastJoin(): Boolean = {return _BroadcastJoin}
   
+  private var _externalCode: String = "HUEMUL_DQ_001"
+  def getExternalCode: String = {return if (_externalCode==null) "HUEMUL_DQ_001" else _externalCode }
+  def setExternalCode(value: String) {
+    _externalCode = value  
+  }
+  
 }


### PR DESCRIPTION
Implementa los siguientes issues:

#56 incorpora opción para dejar registros en detalle de DQ cuando se utiliza el método executeOnlyInsert
#58 Excluye registros que no cumplen con condiciones de DQ (con huemul_DataQuality y FK)
#60 Incluye Id de DQ en la tabla de detalle de DQ: permite enlazar modelo de control con detalle de DQ
#62 Incorpora detalle del avance en las reglas de DQ, y posibilidad de separar la ejecución para ambientes pequeños.
#64 Crea método savePersistToDisk para guardar el resultado de un DF en HDFS
#68 Permite crear cache de metadata de HIVE para mejorar tiempo de respuesta al inicio de ejecución.
#71 Incorpora versión del modelo de control para mejorar la compatibilidad entre versiones.
#72 Guarda la versión de huemul y modelo de control ejecutados en la tabla control_processExec
#73 Parametrizar los códigos de error externos para PK y FK
#63 Optimización de código: