### PR TITLE
Develop hbase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
-      <version>${hbase.client.version}</version>
+      <version>2.1.0</version>
     </dependency>
      <!-- https://mvnrepository.com/artifact/org.apache.hbase.connectors.spark/hbase-spark -->
    <dependency>
@@ -124,6 +124,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
      <artifactId>hbase-spark</artifactId>
      <version>1.0.0</version>
    </dependency>
+    
     
     <!-- Test -->
     <dependency>
@@ -202,7 +203,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	  
 	</build>
 
-
+ <!--
 <repositories>
 	<repository>
       <id>scala-tools.org</id>
@@ -232,8 +233,18 @@ Finalmente, también automatiza la generación de código a partir de las defini
      <name>Hortonworks Other Dependencies</name>
      <url>http://repo.hortonworks.com/content/groups/public</url>
     </repository>
+    
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
 </repositories>
-
+-->
  
   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@ Finalmente, también automatiza la generación de código a partir de las defini
     <scala.tools.version>2.11</scala.tools.version>
     <scala.version>2.11.8</scala.version>
     <spark.version>2.2.1</spark.version>
+    <hbase.client.version>2.1.0</hbase.client.version>
+    <hbase-spark.version>1.0.0</hbase-spark.version>
   </properties>
 
   <dependencies>
@@ -104,17 +106,25 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	
 
 
-	<!-- https://mvnrepository.com/artifact/com.hortonworks.shc/shc-core -->
+	<!-- https://mvnrepository.com/artifact/com.hortonworks.shc/shc-core 
 	<dependency>
 	    <groupId>com.hortonworks.shc</groupId>
 	    <artifactId>shc-core</artifactId>
 	    <version>1.1.0.3.1.2.1-1</version>
 	</dependency>
-		
-
-
-
-
+		-->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase.client.version}</version>
+    </dependency>
+     <!-- https://mvnrepository.com/artifact/org.apache.hbase.connectors.spark/hbase-spark -->
+   <dependency>
+     <groupId>org.apache.hbase.connectors.spark</groupId>
+     <artifactId>hbase-spark</artifactId>
+     <version>1.0.0</version>
+   </dependency>
+    
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
@@ -195,6 +205,11 @@ Finalmente, también automatiza la generación de código a partir de las defini
 
 <repositories>
 	<repository>
+      <id>scala-tools.org</id>
+      <name>Scala-Tools Maven2 Repository</name>
+      <url>http://scala-tools.org/repo-releases</url>
+    </repository>
+	<repository>
      <releases>
       <enabled>true</enabled>
      </releases>
@@ -218,7 +233,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
      <url>http://repo.hortonworks.com/content/groups/public</url>
     </repository>
 </repositories>
-  
+
  
   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -97,34 +97,130 @@ Finalmente, también automatiza la generación de código a partir de las defini
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.tools.version}</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
 
 	<dependency>
        <groupId>org.apache.hive</groupId>
        <artifactId>hive-jdbc</artifactId>
        <version>1.1.0</version>
 	</dependency>
+ 
+
+	<dependency>
+	    <groupId>org.apache.hbase.connectors.spark</groupId>
+     	<artifactId>hbase-spark</artifactId>
+    	<version>1.0.0</version>
+   	</dependency>
+
+	<dependency>
+		<groupId>jdk.tools</groupId>
+		<artifactId>jdk.tools</artifactId>
+		<version>1.7.0_05</version>
+		<scope>system</scope>
+		<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
+	</dependency>
+	<!-- 
+	<dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-spark</artifactId>
+        <version>1.1.2.2.6.4.0-91</version>
+    </dependency>
+    -->
+    <dependency>
+	   <groupId>org.apache.hbase</groupId>
+	   <artifactId>hbase-client</artifactId>
+	   <version>1.1.2</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    
+   	<dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-protocol</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+
+     <dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-annotations</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+
+  	 <dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-hadoop-compat</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+     
+     <dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-hadoop2-compat</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+	<!-- https://mvnrepository.com/artifact/com.hortonworks.shc/shc-core -->
+
 	
 
-
-	<!-- https://mvnrepository.com/artifact/com.hortonworks.shc/shc-core 
+  <!-- 
+		  
 	<dependency>
-	    <groupId>com.hortonworks.shc</groupId>
-	    <artifactId>shc-core</artifactId>
-	    <version>1.1.0.3.1.2.1-1</version>
+		<groupId>jdk.tools</groupId>
+		<artifactId>jdk.tools</artifactId>
+		<version>1.7.0_05</version>
+		<scope>system</scope>
+		<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
 	</dependency>
-		-->
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
-      <version>2.1.0</version>
+      <version>1.1.2</version>
     </dependency>
-     <!-- https://mvnrepository.com/artifact/org.apache.hbase.connectors.spark/hbase-spark -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    
+   	<dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-protocol</artifactId>
+          <version>1.1.2</version>
+      </dependency>
+
+      <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-annotations</artifactId>
+          <version>1.1.2</version>
+      </dependency>
+
+	  <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-hadoop-compat</artifactId>
+          <version>1.1.2</version>
+      </dependency>
+      
+
+      <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-spark</artifactId>
+          <version>2.0.0-alpha4</version>
+      </dependency>
+      -->
+     <!-- https://mvnrepository.com/artifact/org.apache.hbase.connectors.spark/hbase-spark 
    <dependency>
      <groupId>org.apache.hbase.connectors.spark</groupId>
      <artifactId>hbase-spark</artifactId>
      <version>1.0.0</version>
    </dependency>
-    
+    -->
     
     <!-- Test -->
     <dependency>
@@ -204,6 +300,26 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	</build>
 
  <!--
+<repositories>
+	<repository>
+     <id>hortonworks.extrepo</id>
+     <name>Hortonworks HDP</name>
+     <url>http://repo.hortonworks.com/content/repositories/releases</url>
+    </repository>
+
+    <repository>
+     <id>hortonworks.other</id>
+     <name>Hortonworks Other Dependencies</name>
+     <url>http://repo.hortonworks.com/content/groups/public</url>
+    </repository>
+    
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+</repositories>
+
 <repositories>
 	<repository>
       <id>scala-tools.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -101,12 +101,18 @@ Finalmente, también automatiza la generación de código a partir de las defini
        <artifactId>hive-jdbc</artifactId>
        <version>1.1.0</version>
 	</dependency>
+	
 
+
+	<!-- https://mvnrepository.com/artifact/com.hortonworks.shc/shc-core -->
 	<dependency>
 	    <groupId>com.hortonworks.shc</groupId>
 	    <artifactId>shc-core</artifactId>
 	    <version>1.1.0.3.1.2.1-1</version>
 	</dependency>
+		
+
+
 
 
     <!-- Test -->
@@ -186,6 +192,32 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	  
 	</build>
 
+
+<repositories>
+	<repository>
+     <releases>
+      <enabled>true</enabled>
+     </releases>
+     <snapshots>
+      <enabled>true</enabled>
+     </snapshots>
+     <id>hortonworks.extrepo</id>
+     <name>Hortonworks HDP</name>
+     <url>http://repo.hortonworks.com/content/repositories/releases</url>
+    </repository>
+
+    <repository>
+     <releases>
+      <enabled>true</enabled>
+     </releases>
+     <snapshots>
+      <enabled>true</enabled>
+     </snapshots>
+     <id>hortonworks.other</id>
+     <name>Hortonworks Other Dependencies</name>
+     <url>http://repo.hortonworks.com/content/groups/public</url>
+    </repository>
+</repositories>
   
  
   

--- a/pom.xml
+++ b/pom.xml
@@ -95,16 +95,19 @@ Finalmente, también automatiza la generación de código a partir de las defini
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>                                                      
-	   <groupId>org.postgresql</groupId>
-	   <artifactId>postgresql</artifactId>
-	   <version>9.4.1212</version>                                
-	</dependency> 
+
 	<dependency>
        <groupId>org.apache.hive</groupId>
        <artifactId>hive-jdbc</artifactId>
        <version>1.1.0</version>
 	</dependency>
+
+	<dependency>
+	    <groupId>com.hortonworks.shc</groupId>
+	    <artifactId>shc-core</artifactId>
+	    <version>1.1.0.3.1.2.1-1</version>
+	</dependency>
+
 
     <!-- Test -->
     <dependency>

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -411,6 +411,8 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
    *************************/
   @transient val CONTROL_connection= new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.CONTROL_Setting),GlobalSettings.CONTROL_Driver, DebugMode) // Connection = null
   @transient val impala_connection = new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.IMPALA_Setting),"com.cloudera.impala.jdbc4.Driver", DebugMode) //Connection = null
+  //FROM 2.2 --> ADD Hive connection to create HBase tables
+  @transient val HIVE_connection   = new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.HIVE_Setting),null, DebugMode) //Connection = null
   
   if (!TestPlanMode && RegisterInControl) { 
     logMessageInfo(s"establishing connection with control model")  
@@ -419,6 +421,15 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   if (!TestPlanMode && ImpalaEnabled) {
     logMessageInfo(s"establishing connection with impala") 
     impala_connection.StartConnection()
+  }
+  //from 2.2 --> start HIVE Connection
+  if (!TestPlanMode) {
+    if (GlobalSettings.ValidPath(GlobalSettings.HIVE_Setting, this.Environment)) {
+      logMessageInfo(s"establishing connection with JDBC HIVE")
+      impala_connection.StartConnection()
+    } else {
+      logMessageWarn(s"can't establish connection with JDBC HIVE (HIVE_Setting's missing)")
+    }
   }
   
   val spark: SparkSession = if (!TestPlanMode & LocalSparkSession == null) 

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -412,7 +412,8 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   @transient val CONTROL_connection= new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.CONTROL_Setting),GlobalSettings.CONTROL_Driver, DebugMode) // Connection = null
   @transient val impala_connection = new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.IMPALA_Setting),"com.cloudera.impala.jdbc4.Driver", DebugMode) //Connection = null
   //FROM 2.2 --> ADD Hive connection to create HBase tables
-  @transient val HIVE_connection   = new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.HIVE_Setting),null, DebugMode) //Connection = null
+  val _HIVE_connString: String = if (GlobalSettings.ValidPath(GlobalSettings.HIVE_Setting, this.Environment)) GlobalSettings.GetPath(this, GlobalSettings.HIVE_Setting) else ""
+  @transient val HIVE_connection   = new huemul_JDBCProperties(this, _HIVE_connString,null, DebugMode) //Connection = null
   
   if (!TestPlanMode && RegisterInControl) { 
     logMessageInfo(s"establishing connection with control model")  
@@ -426,7 +427,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   if (!TestPlanMode) {
     if (GlobalSettings.ValidPath(GlobalSettings.HIVE_Setting, this.Environment)) {
       logMessageInfo(s"establishing connection with JDBC HIVE")
-      impala_connection.StartConnection()
+      HIVE_connection.StartConnection()
     } else {
       logMessageWarn(s"can't establish connection with JDBC HIVE (HIVE_Setting's missing)")
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -986,7 +986,11 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     if (numPartitions != null && numPartitions > 0)
       SQL_DF = SQL_DF.repartition(numPartitions)      
       
-    if (this.DebugMode) SQL_DF.show()
+    
+    if (this.DebugMode) {
+      this.logMessageDebug(s"alias: ${Alias}")
+      SQL_DF.show()
+    }
     //Change alias name
     SQL_DF.createOrReplaceTempView(Alias)         //crea vista sql
 

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -158,19 +158,26 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
           //spark.catalog.listColumns(x.database, x.name).show(10000)
           var listcols:org.apache.spark.sql.Dataset[org.apache.spark.sql.catalog.Column]= null
     
-          if (x.database == null)
-            listcols = spark.catalog.listColumns(x.name)
-          else
-            listcols = spark.catalog.listColumns(x.database, x.name)
-            
-          listcols.collect().foreach { y =>
-            //println(s"database: ${x.database}, table: ${x.name}, column: ${y.name}")
-            val newRow = new huemul_sql_tables_and_columns()
-            newRow.column_name = y.name
-            newRow.database_name = if (x.database == null) "__temporary" else x.database
-            newRow.table_name = x.name
-            _ColumnsAndTables.append(newRow)
-          }  
+          try {
+            if (x.database == null)
+              listcols = spark.catalog.listColumns(x.name)
+            else
+              listcols = spark.catalog.listColumns(x.database, x.name)
+              
+            listcols.collect().foreach { y =>
+              //println(s"database: ${x.database}, table: ${x.name}, column: ${y.name}")
+              val newRow = new huemul_sql_tables_and_columns()
+              newRow.column_name = y.name
+              newRow.database_name = if (x.database == null) "__temporary" else x.database
+              newRow.table_name = x.name
+              _ColumnsAndTables.append(newRow)
+            }  
+          } catch {
+            case e: Exception =>
+              println(s"Error reading HIVE metadata on table ${x.database}.${x.name}")
+              println(e)
+              
+          }
         }
       }
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -73,7 +73,8 @@ class huemul_GlobalPath() extends Serializable {
     
     //FROM 2.2
     //Add Hbase available
-    var _HBase_available: Boolean = false
+    private var _HBase_available: Boolean = false
+    dev getHBase_available(): Boolean = {return _HBase_available}
     def setHBase_available() {
       _HBase_available = true
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -71,6 +71,13 @@ class huemul_GlobalPath() extends Serializable {
     //set > 1 to cache hive metadata
     var HIVE_HourToUpdateMetadata: Integer = 0
     
+    //FROM 2.2
+    //Add Hbase available
+    var _HBase_available: Boolean = false
+    def setHBase_available() {
+      _HBase_available = true
+    }
+    
     /**
      Returns true if path has value, otherwise return false
      */

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -78,6 +78,12 @@ class huemul_GlobalPath() extends Serializable {
     def setHBase_available() {
       _HBase_available = true
     }
+    private var _HBase_formatTable: String = "org.apache.spark.sql.execution.datasources.hbase"
+    def setHBase_formatTable(value: String) {
+      _HBase_formatTable = value
+    }
+    def getHBase_formatTable(): String = {return _HBase_formatTable}
+    
     
     /**
      Returns true if path has value, otherwise return false

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -74,7 +74,7 @@ class huemul_GlobalPath() extends Serializable {
     //FROM 2.2
     //Add Hbase available
     private var _HBase_available: Boolean = false
-    dev getHBase_available(): Boolean = {return _HBase_available}
+    def getHBase_available(): Boolean = {return _HBase_available}
     def setHBase_available() {
       _HBase_available = true
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -21,6 +21,9 @@ class huemul_GlobalPath() extends Serializable {
     val CONTROL_Setting: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     val IMPALA_Setting: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     
+    //from 2.2 --> add HIVE connect
+    val HIVE_Setting: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
+    
     //RAW
     val RAW_SmallFiles_Path: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     val RAW_BigFiles_Path: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
@@ -78,11 +81,14 @@ class huemul_GlobalPath() extends Serializable {
     def setHBase_available() {
       _HBase_available = true
     }
+    /*
     private var _HBase_formatTable: String = "org.apache.spark.sql.execution.datasources.hbase"
     def setHBase_formatTable(value: String) {
       _HBase_formatTable = value
     }
     def getHBase_formatTable(): String = {return _HBase_formatTable}
+    * 
+    */
     
     
     /**

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -139,7 +139,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
       if (!Ejec.IsError && ApplicationInUse == null)
         ContinueInLoop = false
       else {      
-        if (huemulBigDataGov.DebugMode) phuemulBigDataGov.logMessageDebug(s"waiting for Singleton... (class: $Control_ClassName, appId: ${huemulBigDataGov.IdApplication} )")
+        phuemulBigDataGov.logMessageDebug(s"waiting for Singleton... (class: $Control_ClassName, appId: ${huemulBigDataGov.IdApplication} )")
         //if has error, verify other process still alive
         if (NumCycle == 1) //First cicle don't wait
           Thread.sleep(10000)

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -54,8 +54,10 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
   var Control_Start_dt: Calendar = Calendar.getInstance()
   var Control_Stop_dt: Calendar = null
   val Control_Error: huemul_ControlError = new huemul_ControlError(huemulBigDataGov)
-  val Control_Params: scala.collection.mutable.ListBuffer[huemul_LibraryParams] = new scala.collection.mutable.ListBuffer[huemul_LibraryParams]() 
+  val Control_Params: scala.collection.mutable.ListBuffer[huemul_LibraryParams] = new scala.collection.mutable.ListBuffer[huemul_LibraryParams]()
+  
   private var LocalIdStep: String = ""
+  def getStepId: String = return LocalIdStep 
   private var Step_IsDQ: Boolean = false
   private var AdditionalParamsInfo: String = ""
   

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_JDBCResult.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_JDBCResult.scala
@@ -93,6 +93,7 @@ class huemul_JDBCProperties(huemulBigDataGob: huemul_BigDataGovernance,  connect
     var Result: huemul_JDBCResult = new huemul_JDBCResult()
     
     var i = 0
+    if (connection == null) sys.error("error JDBC connection failed")
     while (i<=2 && connection.isClosed()) {
       huemulBigDataGob.logMessageWarn("CONTROL connection closed, trying to establish new connection")
       StartConnection()
@@ -221,6 +222,7 @@ class huemul_JDBCProperties(huemulBigDataGob: huemul_BigDataGovernance,  connect
     //val url = ""
    
     var i = 0
+    if (connection == null) sys.error("error JDBC connection failed")
     while (i<=2 && connection.isClosed()) {
       huemulBigDataGob.logMessageWarn("CONTROL connection closed, trying to establish new connection")
       StartConnection()

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_InternalTableType.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_InternalTableType.scala
@@ -1,0 +1,6 @@
+package com.huemulsolutions.bigdata.tables
+
+object huemulType_InternalTableType extends Enumeration {
+  type huemulType_InternalTableType = Value
+  val Normal, DQ, OldValueTrace = Value
+}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_StorageType.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_StorageType.scala
@@ -2,5 +2,5 @@ package com.huemulsolutions.bigdata.tables
 
 object huemulType_StorageType extends Enumeration {
   type huemulType_StorageType = Value
-  val PARQUET, ORC, AVRO = Value
+  val PARQUET, ORC, AVRO, HBASE = Value
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_Tables.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_Tables.scala
@@ -6,7 +6,3 @@ object huemulType_Tables extends Enumeration {
 }
 
 
-object huemulType_InternalTableType extends Enumeration {
-  type huemulType_InternalTableType = Value
-  val Normal, DQ, OldValueTrace = Value
-}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
@@ -454,4 +454,16 @@ class huemul_Columns(param_DataType: DataType
     this.SQLForInsert = SQLForInsert
   }
   
+  //from 2.2 --> add setting to HBase
+  private var _hive_df: String = "default"
+  private var _hive_col: String = null
+  def setHBaseCatalogMapping(df: String, col: String = null): huemul_Columns = {
+    _hive_df = df
+    _hive_col = col
+    this
+  }
+  
+  def getHBaseCatalogFamily(): String = {return _hive_df}
+  def getHBaseCatalogColumn(): String = {return _hive_col}
+  
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
@@ -457,6 +457,10 @@ class huemul_Columns(param_DataType: DataType
   //from 2.2 --> add setting to HBase
   private var _hive_df: String = "default"
   private var _hive_col: String = null
+  
+  /**
+   * Define family and column name on HBase Tables 
+   */
   def setHBaseCatalogMapping(df: String, col: String = null): huemul_Columns = {
     _hive_df = df
     _hive_col = col
@@ -464,6 +468,19 @@ class huemul_Columns(param_DataType: DataType
   }
   
   def getHBaseCatalogFamily(): String = {return _hive_df}
-  def getHBaseCatalogColumn(): String = {return _hive_col}
+  def getHBaseCatalogColumn(): String = {return if (_hive_col == null) get_MyName() else _hive_col}
   
+  def getHBaseDataType(): String = {
+    return if (DataType == DataTypes.StringType) "string"
+      else if (DataType == DataTypes.IntegerType) "int"
+      else if (DataType == DataTypes.ShortType) "smallint"
+      else if (DataType == DataTypes.BooleanType) "boolean"
+      else if (DataType == DataTypes.DoubleType) "double"
+      else if (DataType == DataTypes.FloatType) "float"
+      else if (DataType == DataTypes.LongType) "bigint"
+      else if (DataType == DataTypes.ShortType) "tinyint"
+      else if (DataType == DataTypes.BinaryType) "binary"
+      else "string"
+        
+  }
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -766,8 +766,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    */
   private def getALLDeclaredFields_forHBase(allDeclaredFields: Array[java.lang.reflect.Field]) : Array[(java.lang.reflect.Field, String, String)] = {
        
-    val result = allDeclaredFields.map { x =>     
+    val result = allDeclaredFields.filter { x => x.setAccessible(true)
+                                      x.get(this).isInstanceOf[huemul_Columns] }.map { x =>     
       //Get field
+      x.setAccessible(true)
       var Field = x.get(this).asInstanceOf[huemul_Columns]
       (x,Field.getHBaseCatalogFamily(), Field.getHBaseCatalogColumn())
     }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -120,12 +120,17 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    Type of Persistent storage (parquet, csv, json) for DQ
    */
   def setStorageType_DQResult(value: huemulType_StorageType) {
+    if (_StorageType_DQResult == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for DQ Table", 1061)
+      
     if (DefinitionIsClose)
       this.raiseError("You can't change value of StorageType_DQResult, definition is close", 1033)
     else
       _StorageType_DQResult = value
   }
   def getStorageType_DQResult: huemulType_StorageType = {
+    if (_StorageType_DQResult == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for DQ Table", 1061)
     return   if (_StorageType_DQResult != null) _StorageType_DQResult
         else if (_StorageType_DQResult == null && getStorageType == huemulType_StorageType.HBASE ) _storageType_default  
         else getStorageType
@@ -136,12 +141,17 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    Type of Persistent storage (parquet, csv, json) for DQ
    */
   def setStorageType_OldValueTrace(value: huemulType_StorageType) {
+    if (_StorageType_OldValueTrace == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for OldValueTraceTable", 1063)
+      
     if (DefinitionIsClose)
       this.raiseError("You can't change value of StorageType_OldValueTrace, definition is close", 1033)
     else
       _StorageType_OldValueTrace = value
   }
   def getStorageType_OldValueTrace: huemulType_StorageType = {
+    if (_StorageType_OldValueTrace == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for OldValueTraceTable", 1063)
     return   if (_StorageType_OldValueTrace != null) _StorageType_OldValueTrace
         else if (_StorageType_OldValueTrace == null && getStorageType == huemulType_StorageType.HBASE ) _storageType_default  
         else getStorageType    
@@ -674,6 +684,12 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       
     if (this.getStorageType == null)
       raiseError(s"huemul_Table Error: StorageType must be defined",1002)
+      
+    if (this.getStorageType_DQResult == null)
+      raiseError(s"huemul_Table Error: HBase is not available for DQ Table",1061)
+      
+    if (this.getStorageType_OldValueTrace == null)
+      raiseError(s"huemul_Table Error: HBase is not available for OldValueTraceTable",1063)
       
     if (this._TableType == null)
       raiseError(s"huemul_Table Error: TableType must be defined",1034)
@@ -3330,8 +3346,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       
     try {      
       LocalControl.NewStep("Save DQ Result: Saving new DQ result")
-      //from 2.2 --> add HBase storage (from table definition)
-      if (this.getStorageType == huemulType_StorageType.HBASE) {
+      //from 2.2 --> add HBase storage (from table definition) --> NOT SUPPORTED
+      if (this.getStorageType_DQResult == huemulType_StorageType.HBASE) {
         val huemulDriver = new huemul_TableConnector(huemulBigDataGov, LocalControl)
         huemulDriver.saveToHBase(DF_Final
                                   ,getHBaseNamespace(huemulType_InternalTableType.DQ)
@@ -3343,7 +3359,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                   )      
       } else {
         if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${getFullNameWithPath_DQ()} ")        
-        DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(this.getStorageType.toString()).partitionBy("dq_control_id").save(getFullNameWithPath_DQ())
+        DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(this.getStorageType_DQResult.toString()).partitionBy("dq_control_id").save(getFullNameWithPath_DQ())
       }
       
     } catch {

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -12,38 +12,29 @@ import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.permission.FsPermission
 import huemulType_Tables._
 import huemulType_StorageType._
-import com.huemulsolutions.bigdata._
+//import com.huemulsolutions.bigdata._
 import com.huemulsolutions.bigdata.dataquality.huemul_DataQuality
 import com.huemulsolutions.bigdata.dataquality.huemul_DataQualityResult
 import com.huemulsolutions.bigdata.common._
-import com.huemulsolutions.bigdata.control._
-
-import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel
-import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification
-import com.huemulsolutions.bigdata.dataquality.huemul_DQRecord
+import com.huemulsolutions.bigdata.control.huemul_Control
 import com.huemulsolutions.bigdata.control.huemulType_Frequency
 import com.huemulsolutions.bigdata.control.huemulType_Frequency._
-import com.huemulsolutions.bigdata.tables.huemulType_Tables.huemulType_Tables
+
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel._
+//import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel.huemulType_DQQueryLevel
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification._
+//import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification.huemulType_DQNotification
+import com.huemulsolutions.bigdata.dataquality.huemul_DQRecord
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency.huemulType_Frequency
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency.huemulType_Frequency
+//import com.huemulsolutions.bigdata.tables.huemulType_Tables.huemulType_Tables
 import com.huemulsolutions.bigdata.tables.huemulType_InternalTableType._
 import com.huemulsolutions.bigdata.datalake.huemul_DataLake
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency.huemulType_Frequency
 
-import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
-import org.apache.hadoop.hbase.spark.HBaseContext
-import org.apache.hadoop.hbase.spark.HBaseRDDFunctions._
-import org.apache.hadoop.hbase.client.{Connection,ConnectionFactory,HBaseAdmin,HTable,Put,Get}
-import org.apache.hadoop.hbase.util.Bytes
-import org.apache.hadoop.hbase.spark.KeyFamilyQualifier
-import org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles
-import org.apache.hadoop.hbase.client.Delete
-import org.apache.hadoop.hbase.client.Admin
-//import org.apache.hadoop.hbase.HTableDescriptors // HTableDescriptor
-import org.apache.hadoop.hbase.HColumnDescriptor
-import org.apache.hive.jdbc.HiveConnection
-
-//import org.apache.hadoop.hbase.client.TableDescriptorBuilder
-//import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder
-
-//import org.apache.hadoop.hbase.ColumnDescriptor
 
 
 class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_Control) extends huemul_TableDQ with Serializable  {
@@ -330,11 +321,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   val MDM_AutoInc = new huemul_Columns (LongType, true, "auto incremental for version control", false).setHBaseCatalogMapping("loginfo")
   val processExec_id = new huemul_Columns (StringType, true, "Process Execution Id (control model)", false).setHBaseCatalogMapping("loginfo")
   
-  val MDM_fhNew = new huemul_Columns (TimestampType, true, "Fecha/hora cuando se insertaron los datos nuevos", false).setHBaseCatalogMapping("loginfo9")
-  val MDM_ProcessNew = new huemul_Columns (StringType, false, "Nombre del proceso que insertó los datos", false).setHBaseCatalogMapping("loginfo3")
-  val MDM_fhChange = new huemul_Columns (TimestampType, false, "fecha / hora de último cambio de valor en los campos de negocio", false).setHBaseCatalogMapping("loginfo2")
-  val MDM_ProcessChange = new huemul_Columns (StringType, false, "Nombre del proceso que cambió los datos", false).setHBaseCatalogMapping("loginfo4")
-  val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false).setHBaseCatalogMapping("loginfo2")
+  val MDM_fhNew = new huemul_Columns (TimestampType, true, "Fecha/hora cuando se insertaron los datos nuevos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_ProcessNew = new huemul_Columns (StringType, false, "Nombre del proceso que insertó los datos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_fhChange = new huemul_Columns (TimestampType, false, "fecha / hora de último cambio de valor en los campos de negocio", false).setHBaseCatalogMapping("loginfo")
+  val MDM_ProcessChange = new huemul_Columns (StringType, false, "Nombre del proceso que cambió los datos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false).setHBaseCatalogMapping("loginfo")
   val MDM_hash = new huemul_Columns (StringType, true, "Valor hash de los datos de la tabla", false).setHBaseCatalogMapping("loginfo")
   
   val MDM_columnName = new huemul_Columns (StringType, true, "Column Name", false).setHBaseCatalogMapping("loginfo")
@@ -768,6 +759,20 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
 
     
     return c
+  }
+  
+  /**
+   * Get all declared fields from class, transform to huemul_Columns
+   */
+  private def getALLDeclaredFields_forHBase(allDeclaredFields: Array[java.lang.reflect.Field]) : Array[(java.lang.reflect.Field, String, String)] = {
+       
+    val result = allDeclaredFields.map { x =>     
+      //Get field
+      var Field = x.get(this).asInstanceOf[huemul_Columns]
+      (x,Field.getHBaseCatalogFamily(), Field.getHBaseCatalogColumn())
+    }
+    
+    return result
   }
   
   //private var _SQL_OldValueFullTrace_DF: DataFrame = null 
@@ -2956,168 +2961,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         }
         
        
-        if (this.getStorageType == huemulType_StorageType.HBASE) {
-            var numPartition: String = if (this.getNumPartitions > 5) this.getNumPartitions.toString() else "5"
-            println("cantidad de particiones")
-            println(numPartition)
-            
-            //array with column names
-            val __nomPK = if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey"
-            
-            val __cols = DF_Final.columns.sortBy { x => (if (x==__nomPK) "0" else "1").concat(x) } 
-            val __colSortedDF = DF_Final.select(__cols.map( x => col(x)): _*)
-            val __colFromTable = getALLDeclaredFields(false)
-            
-            //excluir PK
-            val __valCols = __cols.filterNot(x => x.equals(__nomPK)).map { x => {
-              val fam_fil = __colFromTable.filter { y => y.getName.toUpperCase() == x.toUpperCase() }
-              var fam: String = "default"
-              var nom: String = x
-              if (fam_fil.length == 1) {
-                val __reg = fam_fil(0) 
-                __reg.setAccessible(true)
-                var dataField = __reg.get(this).asInstanceOf[huemul_Columns]
-                fam = dataField.getHBaseCatalogFamily()
-                nom = dataField.getHBaseCatalogColumn()
-              }
-              (nom, fam )
-            }}
-            
-            val __numCols: Int = __valCols.length
-    
-            import huemulBigDataGov.spark.implicits._ 
-            val __pdd_2 = __colSortedDF.flatMap(row => {
-              val rowKey = row(0).toString() //Bytes.toBytes(x._1)
-              
-              for (i <- 0 until __numCols) yield {
-                  val colName = __valCols(i)._1.toString()
-                  val famName = __valCols(i)._2.toString()
-                  val colValue = if (row(i+1) == null) null else row(i+1).toString()
-                  
-                  (rowKey, (famName, colName, colValue))
-                }
-              }
-            ).rdd
-            
-            //inicializa HBase
-            val hbaseConf = HBaseConfiguration.create()
-            val hbaseContext = new HBaseContext(huemulBigDataGov.spark.sparkContext, hbaseConf)
-            
-             //ASignación de tabla
-            val stagingFolder = s"/tmp/user/${Control.Control_Id}"
-            println(stagingFolder)
-            val tableNameString: String = s"${getHBaseNamespace()}:${getHBaseTableName()}"
-            val tableName: org.apache.hadoop.hbase.TableName = org.apache.hadoop.hbase.TableName.valueOf(tableNameString)
-            println(tableNameString)
-            
-            //Crea tabla
-            Control.NewStep("HBase: Create connection")
-            val connection = ConnectionFactory.createConnection(hbaseConf)
-            val admin = connection.getAdmin()
-            
-            println("obteniendo namespace")
-            val _listNamespace = admin.listNamespaceDescriptors()
-            
-            //Create namespace if it doesn't exist
-            _listNamespace.foreach { x => println(x.getName) }
-            if (_listNamespace.filter { x => x.getName == getHBaseNamespace }.length == 0) {
-              admin.createNamespace(org.apache.hadoop.hbase.NamespaceDescriptor.create(getHBaseNamespace).build())
-            }
-            
-            Control.NewStep("HBase: Validate TableExists")
-            if (!admin.tableExists(tableName)) {
-              /* desde hbase 2.0
-              val __newTable = TableDescriptorBuilder.newBuilder(tableName)
-                          .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder("default".getBytes).build())
-                          .build()
-                          * 
-                          */
-             
-              Control.NewStep("HBase: Table Def")
-              val __newTable = new org.apache.hadoop.hbase.HTableDescriptor(tableName)
-              
-              //Add families
-              val a = __valCols.map(x=>x._2).distinct.foreach { x => 
-                __newTable.addFamily(new HColumnDescriptor(x))  
-              }
-              
-              Control.NewStep("HBase: Create Table")
-              admin.createTable(__newTable)
-            } else {
-              val _getFamilies = admin.getTableDescriptor(tableName).getFamilies.toArray()
-              var _newFamilies = __valCols.map(x=>x._2).distinct
-              
-              //get current families
-              _getFamilies.foreach { x =>
-                    val _reg = x.asInstanceOf[org.apache.hadoop.hbase.HColumnDescriptor].getNameAsString
-                    println(_reg)
-                      _newFamilies = _newFamilies.filter { y => y != _reg }
-                    }
-              println("las que quedaron:")
-              _newFamilies.foreach { x => println(x) }
-              //Add new families
-              if (_newFamilies.length > 0) {
-                val __oldTable = admin.getTableDescriptor(tableName)
-                val a = _newFamilies.foreach { x => 
-                  println(s"nuevas: ${x}")
-                __oldTable.addFamily(new HColumnDescriptor(x))  
-                }
-                
-                admin.modifyTable(tableName, __oldTable)
-                
-                //sys.error("fin obligatorio")
-              }
-              
-              
-              
-              
-            }
-            
-            //elimina los registros que tengan algún valor en null
-            //si es OnlyInsert no existen los registros anteriormente, por tanto no hay registros nulos que eliminar.
-            if (!OnlyInsert) {
-              Control.NewStep("HBase: nulls values")
-              val __tdd_null = __pdd_2.filter(x=> x._2._3 == null).map(x=>x._1).distinct().map(x=> Bytes.toBytes(x))
-              Control.NewStep("HBase: Delete nulls")
-              hbaseContext.bulkDelete[Array[Byte]](__tdd_null
-                      ,tableName
-                      ,putRecord => new Delete( putRecord)
-              		     
-                      ,4)
-            }
-                
-            Control.NewStep("HBase: prepare insert values")
-            val __tdd_notnull = __pdd_2.filter(x=> x._2._3 != null)
-            Control.NewStep("HBase: insert values")
-            __tdd_notnull.hbaseBulkLoad(hbaseContext
-                                  , tableName
-                                  , t =>  {
-                                    val rowKey = Bytes.toBytes(t._1)
-                                    val family: Array[Byte] = Bytes.toBytes(t._2._1)
-                                    val qualifier = Bytes.toBytes(t._2._2)
-                                    val value = Bytes.toBytes(t._2._3)
-                                    
-                                    val keyFamilyQualifier = new KeyFamilyQualifier(rowKey,family, qualifier)
-                                    Seq((keyFamilyQualifier, value)).iterator
-                                    
-                                  }
-                                  , stagingFolder)
-            
-            
-            val load = new LoadIncrementalHFiles(hbaseConf)
-            Control.NewStep("HBase: Execute")
-            load.run(Array(stagingFolder, tableNameString))
-              
-            
-            /*
-            DF_Final.write.mode(localSaveMode).options(Map(HBaseTableCatalog.tableCatalog -> getHBaseCatalog()
-                                                           , HBaseTableCatalog.newTable -> numPartition)
-                                                        ).format(huemulBigDataGov.GlobalSettings.getHBase_formatTable()).save()
-                                                        * 
-                                                        */
-          }
-       else 
-         DF_Final.write.mode(localSaveMode).format(this._StorageType.toString()).save(getFullNameWithPath())
+        if (this.getStorageType == huemulType_StorageType.HBASE){
+          val huemulDriver = new huemul_TableConnector(huemulBigDataGov, LocalControl)
+          huemulDriver.saveToHBase(DF_Final
+                                  ,getHBaseNamespace()
+                                  ,getHBaseTableName()
+                                  ,this.getNumPartitions //numPartitions
+                                  ,OnlyInsert
+                                  ,if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey" //PKName
+                                  ,getALLDeclaredFields_forHBase(getALLDeclaredFields(false))
+                                  )                                    
+        }
+        else 
+          DF_Final.write.mode(localSaveMode).format(this._StorageType.toString()).save(getFullNameWithPath())
         
         
         //val fs = FileSystem.get(huemulBigDataGov.spark.sparkContext.hadoopConfiguration)       
@@ -3225,6 +3081,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     return Result
     
   }
+    
+  
   
   /**
    * Save DQ Result data to disk

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2621,6 +2621,9 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                               , SQL_Step1_FullJoin(TempAlias, NextAlias, isUpdate, isDelete)
                                               , Control //parent control 
                                              )
+      
+      //from 2.2 --> add to compatibility with HBase (without this, OldValueTrace doesn't work becacuse it recalculate with new HBase values                                       
+      SQLFullJoin_DF.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
                                              
                                              
       //STEP 2: Create Tabla with Update and Insert result

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2539,7 +2539,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
             DFHBase.repartition(this.getNumPartitions).write.mode(SaveMode.Overwrite).format("parquet").save(tempPath)   //2.2 -> this._StorageType.toString() instead of "parquet"
           */
           val numRows = DFHBase.count()
-          DFHBase.show()
+          //DFHBase.show()
         }
       } else {
         if (fs.exists(new org.apache.hadoop.fs.Path(this.getFullNameWithPath()))){
@@ -3118,15 +3118,17 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         
        
         if (this.getStorageType == huemulType_StorageType.HBASE){
-          val huemulDriver = new huemul_TableConnector(huemulBigDataGov, LocalControl)
-          huemulDriver.saveToHBase(DF_Final
-                                  ,getHBaseNamespace(huemulType_InternalTableType.Normal)
-                                  ,getHBaseTableName(huemulType_InternalTableType.Normal)
-                                  ,this.getNumPartitions //numPartitions
-                                  ,OnlyInsert
-                                  ,if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey" //PKName
-                                  ,getALLDeclaredFields_forHBase(getALLDeclaredFields(false))
-                                  )                                    
+          if (DF_Final.count() > 0) {
+            val huemulDriver = new huemul_TableConnector(huemulBigDataGov, LocalControl)
+            huemulDriver.saveToHBase(DF_Final
+                                    ,getHBaseNamespace(huemulType_InternalTableType.Normal)
+                                    ,getHBaseTableName(huemulType_InternalTableType.Normal)
+                                    ,this.getNumPartitions //numPartitions
+                                    ,OnlyInsert
+                                    ,if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey" //PKName
+                                    ,getALLDeclaredFields_forHBase(getALLDeclaredFields(false))
+                                    )
+          }
         }
         else 
           DF_Final.write.mode(localSaveMode).format(this.getStorageType.toString()).save(getFullNameWithPath())

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -3059,6 +3059,9 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    
       if (OnlyInsert && !IsSelectiveUpdate) {
         DF_Final = DF_Final.where("___ActionType__ = 'NEW'") 
+      } else if (this.getStorageType == huemulType_StorageType.HBASE){
+        //exclude "EQUAL" to improve write performance on HBase
+        DF_Final = DF_Final.where("___ActionType__ != 'EQUAL'")
       }
       
       DF_Final = DF_Final.drop("___ActionType__").drop("SameHashKey") //from 2.1: always this columns exist on reference and master tables
@@ -3269,7 +3272,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     try {      
       LocalControl.NewStep("Save: OldVT Result: Saving Old Value Trace result")
       if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${getFullNameWithPath_OldValueTrace()} ")
-      if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET){
+      if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET || getStorageType_OldValueTrace == huemulType_StorageType.ORC){
         DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
         //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(_StorageType_OldValueTrace).save(GetFullNameWithPath_OldValueTrace())
       }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2485,6 +2485,9 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //STEP 2: Execute final table //Add debugmode and getnumpartitions in v1.3
       DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this, storageLevelOfDF)
       
+      //from 2.2 --> persist to improve performance
+      DataFramehuemul.DataFrame.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
+      
       //LocalControl.NewStep("Transaction: Get Statistics info")
       this.UpdateStatistics(LocalControl, "Transaction", null)
       

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -25,6 +25,7 @@ import com.huemulsolutions.bigdata.control.huemulType_Frequency._
 import com.huemulsolutions.bigdata.tables.huemulType_Tables.huemulType_Tables
 import com.huemulsolutions.bigdata.tables.huemulType_InternalTableType._
 import com.huemulsolutions.bigdata.datalake.huemul_DataLake
+import org.apache.spark.sql.execution.datasources.hbase._
 
 //import com.sun.imageio.plugins.jpeg.DQTMarkerSegment
 
@@ -495,6 +496,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     //from 2.2 --> validate tableType with Format
     if (this._TableType == huemulType_Tables.Transaction && !(this._StorageType == huemulType_StorageType.PARQUET || this._StorageType == huemulType_StorageType.ORC))
       raiseError(s"huemul_Table Error: Transaction Tables only available with PARQUET or ORC StorageType ",1057)
+      
+    //Fron 2.2 --> validate tableType HBASE and turn on globalSettings
+    if (this._StorageType == huemulType_StorageType.HBASE && !huemulBigDataGov.GlobalSettings.getHBase_available)
+      raiseError(s"huemul_Table Error: StorageType is set to HBASE, requires invoke HBase_available in globalSettings  ",1058)
       
     if (this._DataBase == null)
       raiseError(s"huemul_Table Error: DataBase must be defined",1037)

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -506,6 +506,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       var dataField = x.get(this).asInstanceOf[huemul_Columns]
       
       if (!(dataField.getIsPK && _numPKColumns == 1)) {        
+        //fields = fields + s""", \n "${x.getName}":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}","type":"${dataField.getHBaseDataType()}"} """
         fields = fields + s""", \n "${x.getName}":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}","type":"${dataField.getHBaseDataType()}"} """
       
         if (tableType != huemulType_InternalTableType.OldValueTrace) {
@@ -550,28 +551,28 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         if (tableType == huemulType_InternalTableType.DQ) {
           //create StructType
           if ("dq_control_id".toUpperCase() != x.getName.toUpperCase()) {
-            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}"""
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}#b"""
           }
         }
         else if (tableType == huemulType_InternalTableType.OldValueTrace) {
           //create StructType MDM_columnName
           if ("MDM_columnName".toUpperCase() != x.getName.toUpperCase()) {
-            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}"""
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}#b"""
           }
         }
         else {
           //create StructType
-          fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}"""
+          fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}${if (dataField.DataType == TimestampType || dataField.DataType == DateType || dataField.DataType == DecimalType || dataField.DataType.typeName.toLowerCase().contains("decimal")) "" else "#b"}"""
           
         }
         
         if (tableType != huemulType_InternalTableType.OldValueTrace) {
           if (dataField.getMDM_EnableOldValue)
-            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_old"""
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_old${if (dataField.DataType == TimestampType || dataField.DataType == DateType || dataField.DataType == DecimalType || dataField.DataType.typeName.toLowerCase().contains("decimal") ) "" else "#b"}"""
           if (dataField.getMDM_EnableDTLog) 
             fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_fhChange"""
           if (dataField.getMDM_EnableProcessLog)
-            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_ProcessLog"""
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_ProcessLog#b"""
         }
         
         
@@ -865,14 +866,14 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   /**
    * Get all declared fields from class, transform to huemul_Columns
    */
-  private def getALLDeclaredFields_forHBase(allDeclaredFields: Array[java.lang.reflect.Field]) : Array[(java.lang.reflect.Field, String, String)] = {
+  private def getALLDeclaredFields_forHBase(allDeclaredFields: Array[java.lang.reflect.Field]) : Array[(java.lang.reflect.Field, String, String, DataType)] = {
        
     val result = allDeclaredFields.filter { x => x.setAccessible(true)
                                       x.get(this).isInstanceOf[huemul_Columns] }.map { x =>     
       //Get field
       x.setAccessible(true)
       var Field = x.get(this).asInstanceOf[huemul_Columns]
-      (x,Field.getHBaseCatalogFamily(), Field.getHBaseCatalogColumn())
+      (x,Field.getHBaseCatalogFamily(), Field.getHBaseCatalogColumn(), Field.DataType)
     }
     
     return result

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -2941,6 +2941,16 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
             var numPartition: String = if (this.getNumPartitions > 5) this.getNumPartitions.toString() else "5"
             println("cantidad de particiones")
             println(numPartition)
+            
+            //array with column names
+            val __cols = DF_Final.columns.filterNot( x => x.equals(if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey")).sorted
+            val __colSorteDF = DF_Final.select(__cols.map(x => col(x)): _*)
+           // val __valCols = __cols.
+           // val __pdd = __colSorteDF.map(row => {
+                
+              
+              
+            
             /*
             DF_Final.write.mode(localSaveMode).options(Map(HBaseTableCatalog.tableCatalog -> getHBaseCatalog()
                                                            , HBaseTableCatalog.newTable -> numPartition)

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -309,19 +309,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    ******************************************************************************** */
   
   
-  val MDM_newValue = new huemul_Columns (StringType, true, "New value updated in table", false)
-  val MDM_oldValue = new huemul_Columns (StringType, true, "Old value", false)
-  val MDM_AutoInc = new huemul_Columns (LongType, true, "auto incremental for version control", false)
-  val processExec_id = new huemul_Columns (StringType, true, "Process Execution Id (control model)", false)
+  val MDM_newValue = new huemul_Columns (StringType, true, "New value updated in table", false).setHBaseCatalogMapping("loginfo")
+  val MDM_oldValue = new huemul_Columns (StringType, true, "Old value", false).setHBaseCatalogMapping("loginfo")
+  val MDM_AutoInc = new huemul_Columns (LongType, true, "auto incremental for version control", false).setHBaseCatalogMapping("loginfo")
+  val processExec_id = new huemul_Columns (StringType, true, "Process Execution Id (control model)", false).setHBaseCatalogMapping("loginfo")
   
-  val MDM_fhNew = new huemul_Columns (TimestampType, true, "Fecha/hora cuando se insertaron los datos nuevos", false)
-  val MDM_ProcessNew = new huemul_Columns (StringType, false, "Nombre del proceso que insertó los datos", false)
-  val MDM_fhChange = new huemul_Columns (TimestampType, false, "fecha / hora de último cambio de valor en los campos de negocio", false)
-  val MDM_ProcessChange = new huemul_Columns (StringType, false, "Nombre del proceso que cambió los datos", false)
-  val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false)
-  val MDM_hash = new huemul_Columns (StringType, true, "Valor hash de los datos de la tabla", false)
+  val MDM_fhNew = new huemul_Columns (TimestampType, true, "Fecha/hora cuando se insertaron los datos nuevos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_ProcessNew = new huemul_Columns (StringType, false, "Nombre del proceso que insertó los datos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_fhChange = new huemul_Columns (TimestampType, false, "fecha / hora de último cambio de valor en los campos de negocio", false).setHBaseCatalogMapping("loginfo")
+  val MDM_ProcessChange = new huemul_Columns (StringType, false, "Nombre del proceso que cambió los datos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false).setHBaseCatalogMapping("loginfo")
+  val MDM_hash = new huemul_Columns (StringType, true, "Valor hash de los datos de la tabla", false).setHBaseCatalogMapping("loginfo")
   
-  val MDM_columnName = new huemul_Columns (StringType, true, "Column Name", false)
+  val MDM_columnName = new huemul_Columns (StringType, true, "Column Name", false).setHBaseCatalogMapping("loginfo")
   
   var AdditionalRowsForDistint: String = ""
   private var DefinitionIsClose: Boolean = false
@@ -402,6 +402,22 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    */
   def getTable_OldValueTrace(): String = {
     return internalGetTable(huemulType_InternalTableType.OldValueTrace)
+  }
+  
+  //new from 2.2
+  def getHBaseCatalog(): String = {
+    var result: String = "{"
+    var fields: String = ""
+    getALLDeclaredFields().filter { x => x.setAccessible(true) 
+                x.get(this).isInstanceOf[huemul_Columns] || x.get(this).isInstanceOf[huemul_DataQuality] || x.get(this).isInstanceOf[huemul_Table_Relationship]  
+    } foreach { x =>
+      x.setAccessible(true)
+      fields = fields + ""
+    }
+    
+    result += "}"
+    
+    return result
   }
   
   

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
@@ -1,0 +1,197 @@
+package com.huemulsolutions.bigdata.tables
+
+import com.huemulsolutions.bigdata.control.huemul_Control
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import com.huemulsolutions.bigdata.common.huemul_BigDataGovernance
+
+
+import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
+import org.apache.hadoop.hbase.spark.HBaseContext
+import org.apache.hadoop.hbase.spark.HBaseRDDFunctions._
+import org.apache.hadoop.hbase.client.{Connection,ConnectionFactory,HBaseAdmin,HTable,Put,Get}
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.spark.KeyFamilyQualifier
+import org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Admin
+//import org.apache.hadoop.hbase.HTableDescriptors // HTableDescriptor
+import org.apache.hadoop.hbase.HColumnDescriptor
+import org.apache.hive.jdbc.HiveConnection
+
+class huemul_TableConnector(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_Control) extends Serializable {
+  
+  def saveToHBase(DF_to_save: DataFrame
+                , HBase_Namespace: String
+                , HBase_tableName: String
+                , numPartitions: Int
+                , isOnlyInsert: Boolean
+                , DF_ColumnPKName: String
+                , huemulDeclaredFieldsForHBase : Array[(java.lang.reflect.Field, String, String)] //Optional
+                ): Boolean = {
+    var result: Boolean = true
+    
+    var numPartition: String = if (numPartitions > 5) numPartitions.toString() else "5"
+    println("cantidad de particiones")
+    println(numPartition)
+    
+    //array with column names    
+    val __cols = DF_to_save.columns.sortBy { x => (if (x==DF_ColumnPKName) "0" else "1").concat(x) } 
+    val __colSortedDF = DF_to_save.select(__cols.map( x => col(x)): _*)
+    
+    //excluir PK
+    val __valCols = __cols.filterNot(x => x.equals(DF_ColumnPKName)).map { x => {
+      var fam: String = "default"
+      var nom: String = x
+      
+      //Only if huemulDeclaredFields has value
+      if (huemulDeclaredFieldsForHBase != null) {
+        val fam_fil = huemulDeclaredFieldsForHBase.filter { y => y._1.getName.toUpperCase() == x.toUpperCase() }
+        
+        if (fam_fil.length == 1) {
+          val __reg = fam_fil(0) 
+          fam = __reg._2
+          nom = __reg._3
+        }
+      }
+      
+      (nom, fam )
+    }}
+    
+    val __numCols: Int = __valCols.length
+
+    import huemulBigDataGov.spark.implicits._ 
+    val __pdd_2 = __colSortedDF.flatMap(row => {
+      val rowKey = row(0).toString() //Bytes.toBytes(x._1)
+      
+      for (i <- 0 until __numCols) yield {
+          val colName = __valCols(i)._1.toString()
+          val famName = __valCols(i)._2.toString()
+          val colValue = if (row(i+1) == null) null else row(i+1).toString()
+          
+          (rowKey, (famName, colName, colValue))
+        }
+      }
+    ).rdd
+    
+    //inicializa HBase
+    val hbaseConf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(huemulBigDataGov.spark.sparkContext, hbaseConf)
+    
+     //ASignación de tabla
+    val stagingFolder = s"/tmp/user/${Control.Control_Id}"
+    println(stagingFolder)
+    val tableNameString: String = s"${HBase_Namespace}:${HBase_tableName}"
+    val tableName: org.apache.hadoop.hbase.TableName = org.apache.hadoop.hbase.TableName.valueOf(tableNameString)
+    println(tableNameString)
+    
+    //Crea tabla
+    Control.NewStep("HBase: Create connection")
+    val connection = ConnectionFactory.createConnection(hbaseConf)
+    val admin = connection.getAdmin()
+    
+    println("obteniendo namespace")
+    val _listNamespace = admin.listNamespaceDescriptors()
+    
+    //Create namespace if it doesn't exist
+    _listNamespace.foreach { x => println(x.getName) }
+    if (_listNamespace.filter { x => x.getName == HBase_Namespace }.length == 0) {
+      admin.createNamespace(org.apache.hadoop.hbase.NamespaceDescriptor.create(HBase_Namespace).build())
+    }
+    
+    Control.NewStep("HBase: Validate TableExists")
+    if (!admin.tableExists(tableName)) {
+      /* desde hbase 2.0
+      val __newTable = TableDescriptorBuilder.newBuilder(tableName)
+                  .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder("default".getBytes).build())
+                  .build()
+                  * 
+                  */
+     
+      Control.NewStep("HBase: Table Def")
+      val __newTable = new org.apache.hadoop.hbase.HTableDescriptor(tableName)
+      
+      //Add families
+      val a = __valCols.map(x=>x._2).distinct.foreach { x => 
+        __newTable.addFamily(new HColumnDescriptor(x))  
+      }
+      
+      Control.NewStep("HBase: Create Table")
+      admin.createTable(__newTable)
+    } else {
+      val __oldTable = admin.getTableDescriptor(tableName)
+      val _getFamilies = __oldTable.getFamilies.toArray()
+      var _newFamilies = __valCols.map(x=>x._2).distinct
+      
+      /*
+       * CHECK FAMILIES
+       */
+      //get current families
+      _getFamilies.foreach { x =>
+            val _reg = x.asInstanceOf[org.apache.hadoop.hbase.HColumnDescriptor].getNameAsString
+            println(_reg)
+              _newFamilies = _newFamilies.filter { y => y != _reg }
+            }
+      println("las que quedaron:")
+      _newFamilies.foreach { x => println(x) }
+      //Add new families
+      if (_newFamilies.length > 0) {
+        
+        val a = _newFamilies.foreach { x => 
+          println(s"nuevas: ${x}")
+        __oldTable.addFamily(new HColumnDescriptor(x))  
+        }
+        
+        admin.modifyTable(tableName, __oldTable)
+        
+        //sys.error("fin obligatorio")
+      }
+                    
+    }
+    
+    //elimina los registros que tengan algún valor en null
+    //si es OnlyInsert no existen los registros anteriormente, por tanto no hay registros nulos que eliminar.
+    if (!isOnlyInsert) {
+      Control.NewStep("HBase: nulls values")
+      val __tdd_null = __pdd_2.filter(x=> x._2._3 == null).map(x=>x._1).distinct().map(x=> Bytes.toBytes(x))
+      Control.NewStep("HBase: Delete nulls")
+      hbaseContext.bulkDelete[Array[Byte]](__tdd_null
+              ,tableName
+              ,putRecord => new Delete( putRecord)
+      		     
+              ,4)
+    }
+        
+    Control.NewStep("HBase: prepare insert values")
+    val __tdd_notnull = __pdd_2.filter(x=> x._2._3 != null)
+    Control.NewStep("HBase: insert values")
+    __tdd_notnull.hbaseBulkLoad(hbaseContext
+                          , tableName
+                          , t =>  {
+                            val rowKey = Bytes.toBytes(t._1)
+                            val family: Array[Byte] = Bytes.toBytes(t._2._1)
+                            val qualifier = Bytes.toBytes(t._2._2)
+                            val value = Bytes.toBytes(t._2._3)
+                            
+                            val keyFamilyQualifier = new KeyFamilyQualifier(rowKey,family, qualifier)
+                            Seq((keyFamilyQualifier, value)).iterator
+                            
+                          }
+                          , stagingFolder)
+    
+    
+    val load = new LoadIncrementalHFiles(hbaseConf)
+    Control.NewStep("HBase: Execute")
+    load.run(Array(stagingFolder, tableNameString))
+      
+    
+    /*
+    DF_to_save.write.mode(localSaveMode).options(Map(HBaseTableCatalog.tableCatalog -> getHBaseCatalog()
+                                                   , HBaseTableCatalog.newTable -> numPartition)
+                                                ).format(huemulBigDataGov.GlobalSettings.getHBase_formatTable()).save()
+                                                * 
+                                                */
+  
+    return result
+  }
+}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
@@ -118,7 +118,7 @@ class huemul_TableConnector(huemulBigDataGov: huemul_BigDataGovernance, Control:
     val __colSortedDF = DF_to_save.select(__cols.map( x => col(x) ): _*)
     val __schema = __colSortedDF.schema
     //exclude PK from columns to save (PK is a row key)
-    val __valCols = __cols.filterNot(x => x.equals(DF_ColumnPKName)).map { x => {
+    val __valCols = __cols.filterNot(x => x.toLowerCase().equals(DF_ColumnPKName.toLowerCase())).map { x => {
       var fam: String = "default"
       var nom: String = x
       var dataType: DataType = __schema.fields( __schema.fieldIndex(x)).dataType
@@ -165,14 +165,14 @@ class huemul_TableConnector(huemulBigDataGov: huemul_BigDataGovernance, Control:
           //else if (colDataType == DataTypes.BinaryType)
           //  colValue = Bytes.toBytes(row.getBinary(i+1))
           else if (colDataType == DataTypes.StringType)
-            colValue = Bytes.toBytes(row.getString(i+1))
+            colValue = Bytes.toBytes(row(i+1).toString())
           //else if (colDataType == DataTypes.NullType)
           //  colValue = Bytes.toBytes(row.getAs[NullType](columnName)
           else if (colDataType == DecimalType || colDataType.typeName.toLowerCase().contains("decimal"))
             colValue = Bytes.toBytes(row(i+1).toString())
             //colValue = Bytes.toBytes(row.getDecimal(i+1))
           else if (colDataType == DataTypes.IntegerType)
-            colValue = Bytes.toBytes(row.getInt(i+1))
+            colValue = Bytes.toBytes(row(i+1).toString()) //Bytes.toBytes(row.getAs[Integer](i+1) )  //(row.getInt(i+1))
           else if (colDataType == DataTypes.FloatType)
             colValue = Bytes.toBytes(row.getFloat(i+1))
           else if (colDataType == DataTypes.DoubleType)

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
@@ -39,9 +39,11 @@ class huemul_TableConnector(huemulBigDataGov: huemul_BigDataGovernance, Control:
     val tableNameString: String = s"${HBase_Namespace}:${HBase_tableName}"
     val tableName: org.apache.hadoop.hbase.TableName = org.apache.hadoop.hbase.TableName.valueOf(tableNameString)
     
-    admin.disableTable(tableName)
-    admin.deleteTable(tableName)
-    
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName)
+      admin.deleteTable(tableName)
+    }
+      
     admin.close()
     connection.close()
     

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
@@ -3,12 +3,12 @@ package com.huemulsolutions.bigdata.tables
 import org.apache.spark.sql.types._
 
 class huemul_TableDQ extends Serializable  {
-  val dq_control_id = new huemul_Columns (StringType, false, "DQ Id partition (control_id)", false)
-  val dq_dq_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false)
-  val dq_error_columnname = new huemul_Columns (StringType, false, "DQ Column Name ", false)
-  val dq_error_notification = new huemul_Columns (StringType, false, "DQ Notification", false)
-  val dq_error_code = new huemul_Columns (StringType, false, "DQ Error Code", false)
-  val dq_error_descripcion = new huemul_Columns (StringType, false, "DQ User error descripcion", false)
+  val dq_control_id = new huemul_Columns (StringType, false, "DQ Id partition (control_id)", false).setHBaseCatalogMapping("dqinfo")
+  val dq_dq_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_columnname = new huemul_Columns (StringType, false, "DQ Column Name ", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_notification = new huemul_Columns (StringType, false, "DQ Notification", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_code = new huemul_Columns (StringType, false, "DQ Error Code", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_descripcion = new huemul_Columns (StringType, false, "DQ User error descripcion", false).setHBaseCatalogMapping("dqinfo")
 
   
 }


### PR DESCRIPTION
Se implementan las siguientes mejoras:

* **#79. Eliminar Backup de tablas maestras y de referencia:** Agrega método control_getBackupToDelete(numBackupToMaintain: Int): Boolean. Recibe el parámetro "numBackupToMaintain" que indica la cantidad de backup que se mantendrán en HDFS (los "N" más nuevos). El resto los elimina.
* **#65. Integración con HBase:** Se agrega soporte para almacenar tablas de referencia y maestras en HBase.
* **#66. Integración con ORC:** Se agrega soporte para almacenar tablas en formato ORC.

Se implementan las siguientes correcciones (bug):
* **#75. Mejorar método control_getDQResultForWarningExclude:** Cuando modelo de control está apagado, se rescata esta información desde un arreglo interno y no desde el modelo de control.