### PR TITLE
V2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
   <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.2</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data lineage for BigData Projects.
   Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@ Finalmente, también automatiza la generación de código a partir de las defini
     <scala.tools.version>2.11</scala.tools.version>
     <scala.version>2.11.8</scala.version>
     <spark.version>2.2.1</spark.version>
+    <hbase.client.version>2.1.0</hbase.client.version>
+    <hbase-spark.version>1.0.0</hbase-spark.version>
   </properties>
 
   <dependencies>
@@ -95,17 +97,131 @@ Finalmente, también automatiza la generación de código a partir de las defini
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>                                                      
-	   <groupId>org.postgresql</groupId>
-	   <artifactId>postgresql</artifactId>
-	   <version>9.4.1212</version>                                
-	</dependency> 
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.tools.version}</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+
 	<dependency>
        <groupId>org.apache.hive</groupId>
        <artifactId>hive-jdbc</artifactId>
        <version>1.1.0</version>
 	</dependency>
+ 
 
+	<dependency>
+	    <groupId>org.apache.hbase.connectors.spark</groupId>
+     	<artifactId>hbase-spark</artifactId>
+    	<version>1.0.0</version>
+   	</dependency>
+
+	<dependency>
+		<groupId>jdk.tools</groupId>
+		<artifactId>jdk.tools</artifactId>
+		<version>1.7.0_05</version>
+		<scope>system</scope>
+		<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
+	</dependency>
+	<!-- 
+	<dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-spark</artifactId>
+        <version>1.1.2.2.6.4.0-91</version>
+    </dependency>
+    -->
+    <dependency>
+	   <groupId>org.apache.hbase</groupId>
+	   <artifactId>hbase-client</artifactId>
+	   <version>1.1.2</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    
+   	<dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-protocol</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+
+     <dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-annotations</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+
+  	 <dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-hadoop-compat</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+     
+     <dependency>
+         <groupId>org.apache.hbase</groupId>
+         <artifactId>hbase-hadoop2-compat</artifactId>
+         <version>1.1.2</version>
+     </dependency>
+	<!-- https://mvnrepository.com/artifact/com.hortonworks.shc/shc-core -->
+
+	
+
+  <!-- 
+		  
+	<dependency>
+		<groupId>jdk.tools</groupId>
+		<artifactId>jdk.tools</artifactId>
+		<version>1.7.0_05</version>
+		<scope>system</scope>
+		<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
+	</dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    
+   	<dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-protocol</artifactId>
+          <version>1.1.2</version>
+      </dependency>
+
+      <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-annotations</artifactId>
+          <version>1.1.2</version>
+      </dependency>
+
+	  <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-hadoop-compat</artifactId>
+          <version>1.1.2</version>
+      </dependency>
+      
+
+      <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-spark</artifactId>
+          <version>2.0.0-alpha4</version>
+      </dependency>
+      -->
+     <!-- https://mvnrepository.com/artifact/org.apache.hbase.connectors.spark/hbase-spark 
+   <dependency>
+     <groupId>org.apache.hbase.connectors.spark</groupId>
+     <artifactId>hbase-spark</artifactId>
+     <version>1.0.0</version>
+   </dependency>
+    -->
+    
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
@@ -183,7 +299,68 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	  
 	</build>
 
-  
+ <!--
+<repositories>
+	<repository>
+     <id>hortonworks.extrepo</id>
+     <name>Hortonworks HDP</name>
+     <url>http://repo.hortonworks.com/content/repositories/releases</url>
+    </repository>
+
+    <repository>
+     <id>hortonworks.other</id>
+     <name>Hortonworks Other Dependencies</name>
+     <url>http://repo.hortonworks.com/content/groups/public</url>
+    </repository>
+    
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+</repositories>
+
+<repositories>
+	<repository>
+      <id>scala-tools.org</id>
+      <name>Scala-Tools Maven2 Repository</name>
+      <url>http://scala-tools.org/repo-releases</url>
+    </repository>
+	<repository>
+     <releases>
+      <enabled>true</enabled>
+     </releases>
+     <snapshots>
+      <enabled>true</enabled>
+     </snapshots>
+     <id>hortonworks.extrepo</id>
+     <name>Hortonworks HDP</name>
+     <url>http://repo.hortonworks.com/content/repositories/releases</url>
+    </repository>
+
+    <repository>
+     <releases>
+      <enabled>true</enabled>
+     </releases>
+     <snapshots>
+      <enabled>true</enabled>
+     </snapshots>
+     <id>hortonworks.other</id>
+     <name>Hortonworks Other Dependencies</name>
+     <url>http://repo.hortonworks.com/content/groups/public</url>
+    </repository>
+    
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+</repositories>
+-->
  
   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
   <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>2.1</version>
+  <version>2.2-SNAPSHOT</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data lineage for BigData Projects.
   Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.

--- a/src/main/resources/Instalacion/huemul_bdg_2.2_minor.sql
+++ b/src/main/resources/Instalacion/huemul_bdg_2.2_minor.sql
@@ -366,10 +366,15 @@ create table  control_tablesuse (			  tablesuse_id            varchar(50)
                                              ,tableuse_numrowsexcluded			  int
 											 ,tableuse_partitionvalue varchar(200)
 											 ,tableuse_pathbackup	  varchar(1000)
+											 ,tableuse_backupstatus			  int
                                              ,mdm_fhcreate            varchar(30)
                                              ,mdm_processname         varchar(200)
                                              ,primary key (tablesuse_id) 
                                             );
+                                            
+                                            
+ CREATE INDEX IDX_control_tablesuse_I01 ON control_tablesuse (tableuse_backupstatus);
+                                             
                     
 create table  control_dq (
                                               dq_id                   varchar(50) 

--- a/src/main/resources/Instalacion/huemul_bdg_2.2_minor.sql
+++ b/src/main/resources/Instalacion/huemul_bdg_2.2_minor.sql
@@ -1,0 +1,468 @@
+
+CREATE TABLE control_config (   config_id		int
+				 				,version_mayor	int
+				                ,version_minor	int
+				                ,version_patch	int
+								,config_dtlog	varchar(50)
+								,primary key (config_id));
+
+create table  control_executors (
+                                              application_id         varchar(100)
+                                             ,idsparkport            varchar(50)
+                                             ,idportmonitoring       varchar(500)
+                                             ,executor_dtstart       varchar(30)
+                                             ,executor_name          varchar(100)
+                                             ,primary key (application_id)
+                                            );
+
+create table  control_singleton (
+                                              singleton_id         varchar(100)
+                                             ,application_id       varchar(100)
+                                             ,singleton_name       varchar(100)
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,primary key (singleton_id)
+                                            );
+        
+create table  control_area (
+                                              area_id              varchar(50)
+											 ,area_idpadre		   varchar(50)
+                                             ,area_name            varchar(100)
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,mdm_processname      varchar(200)
+                                             ,primary key (area_id)
+                                            );
+                             
+create table  control_process ( 
+                                              process_id           varchar(200)
+                                             ,area_id              varchar(50)
+                                             ,process_name         varchar(200)
+                                             ,process_filename     varchar(200)
+                                             ,process_description  varchar(1000)
+                                             ,process_owner        varchar(200)
+											 ,process_frequency    varchar(50)
+                                             ,mdm_manualchange     int
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,mdm_processname      varchar(200)
+                                             ,primary key (process_id)
+                                            );
+                             
+create table  control_processexec ( 
+                                              processexec_id          varchar(50)
+                                             ,processexec_idparent    varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,malla_id                varchar(50)
+                                             ,application_id          varchar(100)
+                                             ,processexec_isstart     int
+                                             ,processexec_iscancelled int
+                                             ,processexec_isenderror  int
+                                             ,processexec_isendok     int
+                                             ,processexec_dtstart     varchar(30)
+                                             ,processexec_dtend       varchar(30)
+                                             ,processexec_durhour     int
+                                             ,processexec_durmin      int
+                                             ,processexec_dursec      int
+                                             ,processexec_whosrun     varchar(200)
+                                             ,processexec_debugmode   int
+                                             ,processexec_environment varchar(200)
+											 ,processexec_param_year	int 
+											 ,processexec_param_month	int 
+											 ,processexec_param_day		int 
+											 ,processexec_param_hour	int 
+											 ,processexec_param_min		int 
+											 ,processexec_param_sec		int 
+											 ,processexec_param_others	varchar(1000) 
+											 ,processexec_huemulversion varchar(50)
+											 ,processexec_controlversion varchar(50)
+                                             ,error_id                varchar(50)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexec_id) 
+                                            );
+                             
+create table  control_processexecparams ( 
+                                              processexec_id          varchar(50)
+                                             ,processexecparams_name  varchar(500)
+                                             ,processexecparams_value varchar(4000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexec_id, processexecparams_name) 
+                                            );
+                   
+create table  control_processexecstep ( 
+                                              processexecstep_id      varchar(50)
+                                             ,processexec_id          varchar(50)
+                                             ,processexecstep_name        varchar(200)
+                                             ,processexecstep_status      varchar(20)  
+                                             ,processexecstep_dtstart     varchar(30)
+                                             ,processexecstep_dtend       varchar(30)
+                                             ,processexecstep_durhour     int
+                                             ,processexecstep_durmin      int
+                                             ,processexecstep_dursec      int
+                                             ,error_id                varchar(50)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexecstep_id) 
+                                            );
+                                            
+                                            
+create table control_query 		(query_id			     varchar(50)
+								,processexecstep_id      varchar(50)
+                                ,processexec_id          varchar(50)      
+                                ,rawfiles_id             varchar(50)
+                                ,rawfilesdet_id		     varchar(50)
+                                ,table_id                varchar(50)
+                                ,query_alias			 varchar(200)
+                                ,query_sql_from		     varchar(4000)
+                                ,query_sql_where		 varchar(4000)
+                                ,query_numerrors	     int
+                                ,query_autoinc			 int
+                                ,query_israw			 int
+                                ,query_isfinaltable	     int
+                                ,query_isquery			 int
+                                ,query_isreferenced		 int
+                                ,query_numrows_real		 int
+                                ,query_numrows_expected  int
+                                ,query_duration_hour	 int
+                                ,query_duration_min		 int
+                                ,query_duration_sec		 int			 
+                                ,error_id                varchar(50)
+                                ,mdm_fhcreate            varchar(30)
+                                ,mdm_processname         varchar(200)    
+                                ,primary key (query_id)
+                                );
+                                
+create table control_querycolumn 	  (querycol_id					varchar(50)
+									  ,query_id						varchar(50)
+									  ,rawfilesdet_id               varchar(50)
+									  ,column_id                  	varchar(50)
+									  ,querycol_pos					int
+									  ,querycol_name				varchar(200)
+									  ,querycol_sql					varchar(4000)
+									  ,querycol_posstart			int
+									  ,querycol_posend				int
+									  ,querycol_line				int
+									  ,mdm_fhcreate            varchar(30)
+                                	  ,mdm_processname         varchar(200)    
+									  ,primary key (querycol_id)
+                                );
+                                
+create index idx_control_querycolumn_i01 on control_querycolumn (query_id, querycol_name);
+                                
+create table control_querycolumnori		(querycolori_id					varchar(50)       
+										,querycol_id					varchar(50)
+										,table_idori                	varchar(50)
+										,column_idori					varchar(50)
+										,rawfilesdet_idori             	varchar(50)
+										,rawfilesdetfields_idori		varchar(50)
+										,query_idori					varchar(50)
+										,querycol_idori					varchar(50)
+										,querycolori_dbname				varchar(200)
+										,querycolori_tabname			varchar(200)
+										,querycolori_tabalias		 	varchar(200)
+										,querycolori_colname			varchar(200)	
+										,querycolori_isselect			int
+										,querycolori_iswhere			int
+										,querycolori_ishaving			int
+										,querycolori_isorder			int
+										,mdm_fhcreate            varchar(30)
+                                		,mdm_processname         varchar(200)    
+										,primary key (querycolori_id)
+                                );				                 
+									                                                                     
+                    
+create table  control_rawfiles ( 
+                                              rawfiles_id             varchar(50)
+                                             ,area_id                 varchar(50)
+                                             ,rawfiles_logicalname    varchar(500)
+                                             ,rawfiles_groupname      varchar(500)
+                                             ,rawfiles_description    varchar(1000)
+                                             ,rawfiles_owner          varchar(200)
+                                             ,rawfiles_frequency      varchar(200)
+                                             ,mdm_manualchange        int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfiles_id) 
+                                            );
+
+create index idx_control_rawfiles_i01 on control_rawfiles (rawfiles_logicalname, rawfiles_groupname);
+create unique index idx_control_rawfiles_i02 on control_rawfiles (rawfiles_logicalname);
+                                    
+create table  control_rawfilesdet ( 
+                                              rawfilesdet_id                            varchar(50)
+                                             ,rawfiles_id                               varchar(50)
+                                             ,rawfilesdet_startdate                     varchar(30)
+                                             ,rawfilesdet_enddate                       varchar(30)
+                                             ,rawfilesdet_filename                      varchar(1000)
+                                             ,rawfilesdet_localpath                     varchar(1000)
+                                             ,rawfilesdet_globalpath                    varchar(1000)
+                                             ,rawfilesdet_data_colseptype         varchar(50)
+                                             ,rawfilesdet_data_colsep             varchar(50)
+                                             ,rawfilesdet_data_headcolstring      varchar(4000)
+                                             ,rawfilesdet_log_colseptype          varchar(50)
+                                             ,rawfilesdet_log_colsep              varchar(50)
+                                             ,rawfilesdet_log_headcolstring       varchar(4000)
+                                             ,rawfilesdet_log_numrowsfield         varchar(200)
+                                             ,rawfilesdet_contactname                   varchar(200)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesdet_id) 
+                                            );
+
+create index idx_control_rawfilesdet_i01 on control_rawfilesdet (rawfiles_id, rawfilesdet_startdate);
+                                                       
+create table  control_rawfilesdetfields ( 
+                                              rawfilesdet_id                  varchar(50)
+											 ,rawfilesdetfields_logicalname          varchar(200)
+                                             ,rawfilesdetfields_itname          varchar(200)
+                                             ,rawfilesdetfields_description          varchar(1000)
+                                             ,rawfilesdetfields_datatype            varchar(50)
+                                             ,rawfilesdetfields_position      int
+                                             ,rawfilesdetfields_posini        int
+                                             ,rawfilesdetfields_posfin        int
+                                             ,rawfilesdetfields_applytrim     int
+                                             ,rawfilesdetfields_convertnull   int
+											 ,mdm_active			  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesdet_id, rawfilesdetfields_logicalname) 
+                                            );
+											
+                  
+create table  control_rawfilesuse ( 
+                                              rawfilesuse_id          varchar(50)
+                                             ,rawfiles_id             varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,rawfilesuse_year        int
+                                             ,rawfilesuse_month       int
+                                             ,rawfilesuse_day         int
+                                             ,rawfilesuse_hour        int
+                                             ,rawfilesuse_minute       int
+                                             ,rawfilesuse_second      int
+                                             ,rawfilesuse_params      varchar(1000)
+                                             ,rawfiles_fullname       varchar(1000)
+                                             ,rawfiles_fullpath       varchar(1000)
+                                             ,rawfiles_numrows        varchar(50)
+                                             ,rawfiles_headerline     varchar(4000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesuse_id) 
+                                            );
+                   
+create table  control_tables ( 
+                                              table_id                varchar(50)
+                                             ,area_id                 varchar(50)
+                                             ,table_bbddname          varchar(200)
+                                             ,table_name              varchar(200)
+                                             ,table_description       varchar(1000)
+                                             ,table_businessowner     varchar(200)
+                                             ,table_itowner           varchar(200)
+                                             ,table_partitionfield    varchar(200)
+                                             ,table_tabletype         varchar(50)  
+											 ,table_compressiontype   varchar(50)  
+                                             ,table_storagetype       varchar(50)
+                                             ,table_localpath         varchar(1000)
+                                             ,table_globalpath        varchar(1000)
+                                             ,table_fullname_dq		  varchar(1200)
+                                             ,table_dq_isused		  int
+                                             ,table_fullname_ovt	  varchar(1200)
+                                             ,table_ovt_isused		  int                                             
+                                             ,table_sqlcreate         varchar(4000)
+											 ,table_frequency		  varchar(200)
+											 ,table_autoincupdate     int
+											 ,table_backup		 	  int
+                                             ,mdm_manualchange        int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)                                             
+                                             ,primary key (table_id) 
+                                            );
+
+create unique index idx_control_tables_i01 on control_tables (table_bbddname, table_name );
+                   
+create table  control_tablesrel (                   
+                                              tablerel_id               varchar(50)
+                                             ,table_idpk                varchar(50)
+                                             ,table_idfk                varchar(50)
+                                             ,tablefk_namerelationship  varchar(100)
+                                             ,tablerel_validnull        int
+                                             ,mdm_manualchange          int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)                                             
+                                             ,primary key (tablerel_id) 
+                                            );
+
+create index idx_control_tablesrel_i01 on control_tablesrel (table_idpk, table_idfk, tablefk_namerelationship); 											
+                    
+create table  control_tablesrelcol ( 
+                                              tablerel_id                varchar(50)
+                                             ,column_idfk                varchar(50)
+                                             ,column_idpk                varchar(50)
+                                             ,mdm_manualchange           int
+                                             ,mdm_fhcreate               varchar(30)
+                                             ,mdm_processname            varchar(200)
+                                             ,primary key (tablerel_id, column_idfk) 
+                                            );
+                                                                       
+                    
+create table  control_columns ( 
+                                              column_id                  varchar(50)
+                                             ,table_id                   varchar(50)
+                                             ,column_position            int
+                                             ,column_name                varchar(200)
+                                             ,column_description         varchar(1000)
+                                             ,column_formula             varchar(1000)
+                                             ,column_datatype            varchar(50)
+                                             ,column_sensibledata        int
+                                             ,column_enabledtlog         int
+                                             ,column_enableoldvalue      int
+                                             ,column_enableprocesslog    int
+                                             ,column_enableoldvaluetrace int
+                                             ,column_defaultvalue        varchar(1000)
+                                             ,column_securitylevel       varchar(200)
+                                             ,column_encrypted           varchar(200)
+                                             ,column_arco                varchar(200)
+                                             ,column_nullable            int
+                                             ,column_ispk                int
+                                             ,column_isunique            int
+                                             ,column_dq_minlen           int
+                                             ,column_dq_maxlen           int 
+                                             ,column_dq_mindecimalvalue  decimal(30,10) 
+                                             ,column_dq_maxdecimalvalue  decimal(30,10) 
+                                             ,column_dq_mindatetimevalue varchar(50) 
+                                             ,column_dq_maxdatetimevalue varchar(50)
+											 ,column_dq_regexp           varchar(1000)
+											 ,column_businessglossary	 varchar(100)
+                                             ,column_responsible         varchar(100)
+                                             ,mdm_active                 int
+                                             ,mdm_manualchange           int
+                                             ,mdm_fhcreate               varchar(30)
+                                             ,mdm_processname            varchar(200)
+                                             ,primary key (column_id) 
+                                            );
+
+create index idx_control_columns_i01 on control_columns (table_id, column_name);
+                                                                       
+                   
+create table  control_tablesuse (			  tablesuse_id            varchar(50)  
+                                             ,table_id                varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,processexecstep_id      varchar(50)
+                                             ,tableuse_year        int
+                                             ,tableuse_month       int
+                                             ,tableuse_day         int
+                                             ,tableuse_hour        int
+                                             ,tableuse_minute       int
+                                             ,tableuse_second      int
+                                             ,tableuse_params      varchar(1000)
+                                             ,tableuse_read           int
+                                             ,tableuse_write          int
+                                             ,tableuse_numrowsnew     int
+                                             ,tableuse_numrowsupdate  int
+											 ,tableuse_numrowsupdatable  int
+											 ,tableuse_numrowsnochange  int
+                                             ,tableuse_numrowsmarkdelete  int
+                                             ,tableuse_numrowstotal   int
+                                             ,tableuse_numrowsexcluded			  int
+											 ,tableuse_partitionvalue varchar(200)
+											 ,tableuse_pathbackup	  varchar(1000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (tablesuse_id) 
+                                            );
+                    
+create table  control_dq (
+                                              dq_id                   varchar(50) 
+                                             ,table_id                varchar(50) 
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,column_id               varchar(50)
+                                             ,column_name             varchar(200)
+                                             ,dq_aliasdf              varchar(200)
+                                             ,dq_name                 varchar(200)
+                                             ,dq_description          varchar(1000)
+                                             ,dq_querylevel           varchar(50)
+                                             ,dq_notification         varchar(50)
+                                             ,dq_sqlformula           varchar(4000)
+                                             ,dq_dq_toleranceerror_rows     int
+                                             ,dq_dq_toleranceerror_percent     decimal(30,10)
+                                             ,dq_resultdq             varchar(4000)
+                                             ,dq_errorcode            int
+                                             ,dq_externalcode         varchar(200)
+                                             ,dq_numrowsok            int
+                                             ,dq_numrowserror         int
+                                             ,dq_numrowstotal         int
+                                             ,dq_iserror              int
+                                             ,dq_iswarning			  int
+                                             ,dq_duration_hour		  int
+                                             ,dq_duration_minute	  int
+                                             ,dq_duration_second	  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (dq_id) 
+                                            );
+                    
+                   
+create table  control_error ( 
+                                              error_id          varchar(50)
+                                             ,error_message                varchar(4000)
+                                             ,error_code           int
+                                             ,error_trace                varchar(4000)
+                                             ,error_classname                varchar(100)
+                                             ,error_filename                varchar(500)
+                                             ,error_linenumber                varchar(100)
+                                             ,error_methodname                varchar(100)
+                                             ,error_detail                varchar(500)
+                                             ,mdm_fhcrea            varchar(30)
+                                             ,mdm_processname         varchar(1000)
+                                             ,primary key (error_id)
+                                            );
+                                                                       
+                  
+create table  control_date ( 
+                                      date_id		varchar(10)
+                                      ,date_year	int
+                                      ,date_month	int
+                                      ,date_day	int
+                                      ,date_dayofweek	int
+                                      ,date_dayname	varchar(20)
+                                      ,date_monthname	varchar(20)
+                                      ,date_quarter	int
+                                      ,date_week	int
+                                      ,date_isweekend	int
+                                      ,date_isworkday	int
+                                      ,date_isbankworkday	int
+                                      ,date_numworkday		int
+                                      ,date_numworkdayrev	int
+                                      ,mdm_fhcreate            varchar(30)
+                                      ,mdm_processname         varchar(200) 
+                                      ,primary key (date_id) 
+                                      );
+                                                                       
+                 
+create table  control_testplan ( 
+                                              testplan_id             varchar(200)
+                                             ,testplangroup_id        varchar(200)
+                                             ,processexec_id          varchar(200)
+                                             ,process_id              varchar(200)
+                                             ,testplan_name           varchar(200)
+                                             ,testplan_description    varchar(1000)
+                                             ,testplan_resultexpected varchar(1000)  
+                                             ,testplan_resultreal     varchar(1000)
+                                             ,testplan_isok           int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (testplan_id) 
+                                            );
+                                            
+create index idx_control_testplan_i01 on control_testplan (testplangroup_id, testplan_name);
+                             
+
+create table  control_testplanfeature ( 
+                                              feature_id              varchar(200)
+                                             ,testplan_id             varchar(200)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (feature_id, testplan_id) 
+                                            );
+                             

--- a/src/main/resources/Instalacion/huemul_cluster_setting_2.2.sh
+++ b/src/main/resources/Instalacion/huemul_cluster_setting_2.2.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+clear
+echo "Creating HDFS Paths: START"
+hdfs dfs -mkdir /user
+hdfs dfs -mkdir /user/data
+hdfs dfs -mkdir /user/data/production
+hdfs dfs -mkdir /user/data/production/temp
+hdfs dfs -mkdir /user/data/production/raw
+hdfs dfs -mkdir /user/data/production/master
+hdfs dfs -mkdir /user/data/production/dim
+hdfs dfs -mkdir /user/data/production/analytics
+hdfs dfs -mkdir /user/data/production/reporting
+hdfs dfs -mkdir /user/data/production/sandbox
+hdfs dfs -mkdir /user/data/production/dqerror
+hdfs dfs -mkdir /user/data/production/mdm_oldvalue
+hdfs dfs -mkdir /user/data/production/backup
+hdfs dfs -mkdir /user/data/experimental
+hdfs dfs -mkdir /user/data/experimental/temp
+hdfs dfs -mkdir /user/data/experimental/raw
+hdfs dfs -mkdir /user/data/experimental/master
+hdfs dfs -mkdir /user/data/experimental/dim
+hdfs dfs -mkdir /user/data/experimental/analytics
+hdfs dfs -mkdir /user/data/experimental/reporting
+hdfs dfs -mkdir /user/data/experimental/sandbox
+hdfs dfs -mkdir /user/data/experimental/dqerror
+hdfs dfs -mkdir /user/data/experimental/mdm_oldvalue
+hdfs dfs -mkdir /user/data/experimental/backup
+echo "Creating HDFS Paths: FINISH"
+echo "STARTING HIVE SETUP"
+hive -e "CREATE DATABASE production_master"
+hive -e "CREATE DATABASE experimental_master"
+hive -e "CREATE DATABASE production_dim"
+hive -e "CREATE DATABASE experimental_dim"
+hive -e "CREATE DATABASE production_analytics"
+hive -e "CREATE DATABASE experimental_analytics"
+hive -e "CREATE DATABASE production_reporting"
+hive -e "CREATE DATABASE experimental_reporting"
+hive -e "CREATE DATABASE production_sandbox"
+hive -e "CREATE DATABASE experimental_sandbox"
+hive -e "CREATE DATABASE production_DQError"
+hive -e "CREATE DATABASE experimental_DQError"
+hive -e "CREATE DATABASE production_mdm_oldvalue"
+hive -e "CREATE DATABASE experimental_mdm_oldvalue"
+echo "STARTING HIVE SETUP"

--- a/src/main/resources/Instalacion/upgrade from 2.1 to 2.2/huemul_bdg_upgrade_2.1_to_2.2.sql
+++ b/src/main/resources/Instalacion/upgrade from 2.1 to 2.2/huemul_bdg_upgrade_2.1_to_2.2.sql
@@ -1,0 +1,18 @@
+
+ ALTER TABLE control_tablesuse add tableuse_backupstatus			  int;
+ /* status null --> old version
+    status 0 --> without backup
+    status 1 --> with backup
+    status 2 --> backup deleted
+ */
+ 
+ CREATE INDEX IDX_control_tablesuse_I01 ON control_tablesuse (tableuse_backupstatus);
+ 
+ UPDATE control_config
+ SET version_mayor	= 2
+    ,version_minor	= 2
+    ,version_patch  = 0
+where config_id = 1;
+
+
+ 

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -52,7 +52,7 @@ import org.apache.log4j.Level
  *  @param LocalSparkSession(opcional) permite enviar una sesión de Spark ya iniciada.
  */
 class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null) extends Serializable  {
-  val currentVersion: String = "2.1"
+  val currentVersion: String = "2.2-SNAPSHOT"
   val GlobalSettings = globalSettings
   val warehouseLocation = new File("spark-warehouse").getAbsolutePath
   //@transient lazy val log_info = org.apache.log4j.LogManager.getLogger(s"$appName [with huemul]")

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -426,6 +426,11 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   }
   
   val IdPortMonitoring = if (!TestPlanMode) spark.sparkContext.uiWebUrl.get else "" 
+    
+  if (!TestPlanMode) {
+    //from 2.2: resolve BUG reading ORC, add set spark.sql.hive.convertMetastoreOrc=true according to SPARK-15705
+    spark.sql("set spark.sql.hive.convertMetastoreOrc=true")
+  }
   
   //spark.sql("set").show(10000, truncate = false)
   //val GetConfigSet = spark.sparkContext.getConf  

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -52,7 +52,7 @@ import org.apache.log4j.Level
  *  @param LocalSparkSession(opcional) permite enviar una sesión de Spark ya iniciada.
  */
 class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null) extends Serializable  {
-  val currentVersion: String = "2.2-SNAPSHOT"
+  val currentVersion: String = "2.2"
   val GlobalSettings = globalSettings
   val warehouseLocation = new File("spark-warehouse").getAbsolutePath
   //@transient lazy val log_info = org.apache.log4j.LogManager.getLogger(s"$appName [with huemul]")

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -67,11 +67,11 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     val inicio = this.getCurrentDateTimeJava()
     
     //try to get hive metadata from cache
-    var getFromHive: Boolean = true
+    //var getFromHive: Boolean = true
     val df_name: String = GlobalSettings.GetDebugTempPath(this, "internal", "temp_hive_metadata") + ".parquet"
     
     //cache is set to true
-    if (this.GlobalSettings.HIVE_HourToUpdateMetadata > 0) {
+    if (this.GlobalSettings.HIVE_HourToUpdateMetadata > 0 && getMetadataFromHive) {
       this.logMessageInfo(s"get Hive Metadata from cache")
       //get from DF
       try {
@@ -94,7 +94,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
           //if elapsed hour > set hour, then refresh from hive
           if (diff_date.days * 24 + diff_date.hour > this.GlobalSettings.HIVE_HourToUpdateMetadata) {
             this.logMessageInfo(s"Time elapsed, must refresh Hive Metadata... ${diff_date.days * 24 + diff_date.hour} (elapsed) > ${this.GlobalSettings.HIVE_HourToUpdateMetadata} (set)")
-            getFromHive = true
+            getMetadataFromHive = true
           } else {
             _ColumnsAndTables = new ArrayBuffer[huemul_sql_tables_and_columns]() 
             DF_get.foreach { x =>
@@ -106,21 +106,21 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
               _ColumnsAndTables.append(newreg) 
             }
             
-            getFromHive = false
+            getMetadataFromHive = false
           }
             
         } else {
-          getFromHive = true
+          getMetadataFromHive = true
         }
       } catch {
         case e: Exception =>
           println(e)
-          getFromHive = true
+          getMetadataFromHive = true
       }
     } 
     
     //get from hive if cache doesn't exists
-    if (getFromHive) {
+    if (getMetadataFromHive) {
       this.logMessageInfo(s"get Hive Metadata from HIVE")
       if (OnlyRefreshTempTables)
         _ColumnsAndTables = _ColumnsAndTables.filter { x_fil => x_fil.database_name != "__temporary" }
@@ -158,26 +158,33 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
           //spark.catalog.listColumns(x.database, x.name).show(10000)
           var listcols:org.apache.spark.sql.Dataset[org.apache.spark.sql.catalog.Column]= null
     
-          if (x.database == null)
-            listcols = spark.catalog.listColumns(x.name)
-          else
-            listcols = spark.catalog.listColumns(x.database, x.name)
-            
-          listcols.collect().foreach { y =>
-            //println(s"database: ${x.database}, table: ${x.name}, column: ${y.name}")
-            val newRow = new huemul_sql_tables_and_columns()
-            newRow.column_name = y.name
-            newRow.database_name = if (x.database == null) "__temporary" else x.database
-            newRow.table_name = x.name
-            _ColumnsAndTables.append(newRow)
-          }  
+          try {
+            if (x.database == null)
+              listcols = spark.catalog.listColumns(x.name)
+            else
+              listcols = spark.catalog.listColumns(x.database, x.name)
+              
+            listcols.collect().foreach { y =>
+              //println(s"database: ${x.database}, table: ${x.name}, column: ${y.name}")
+              val newRow = new huemul_sql_tables_and_columns()
+              newRow.column_name = y.name
+              newRow.database_name = if (x.database == null) "__temporary" else x.database
+              newRow.table_name = x.name
+              _ColumnsAndTables.append(newRow)
+            }  
+          } catch {
+            case e: Exception =>
+              println(s"Error reading HIVE metadata on table ${x.database}.${x.name}")
+              println(e)
+              
+          }
         }
       }
     }
     
     
     
-    if (this.GlobalSettings.HIVE_HourToUpdateMetadata > 0 && getFromHive) {
+    if (this.GlobalSettings.HIVE_HourToUpdateMetadata > 0 && getMetadataFromHive) {
       this.logMessageInfo(s"Save Hive Metadata to cache")
       import spark.implicits._
       val ldt = this.getCurrentDateTime()
@@ -327,6 +334,12 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     sys.error(s"Error: GlobalSettings incomplete!!, you must set $ErrorGlobalSettings ")
   }
   
+  var getMetadataFromHive: Boolean = true
+  try {
+    getMetadataFromHive = arguments.GetValue("getMetadataFromHive", "true" ).toBoolean
+  } catch {    
+    case e: Exception => logMessageError("getMetadataFromHive: error values (true or false)")
+  }
   
   val Malla_Id: String = arguments.GetValue("Malla_Id", "" )
   var HideLibQuery: Boolean = false
@@ -398,6 +411,9 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
    *************************/
   @transient val CONTROL_connection= new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.CONTROL_Setting),GlobalSettings.CONTROL_Driver, DebugMode) // Connection = null
   @transient val impala_connection = new huemul_JDBCProperties(this, GlobalSettings.GetPath(this, GlobalSettings.IMPALA_Setting),"com.cloudera.impala.jdbc4.Driver", DebugMode) //Connection = null
+  //FROM 2.2 --> ADD Hive connection to create HBase tables
+  val _HIVE_connString: String = if (GlobalSettings.ValidPath(GlobalSettings.HIVE_Setting, this.Environment)) GlobalSettings.GetPath(this, GlobalSettings.HIVE_Setting) else ""
+  @transient val HIVE_connection   = new huemul_JDBCProperties(this, _HIVE_connString,null, DebugMode) //Connection = null
   
   if (!TestPlanMode && RegisterInControl) { 
     logMessageInfo(s"establishing connection with control model")  
@@ -406,6 +422,15 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
   if (!TestPlanMode && ImpalaEnabled) {
     logMessageInfo(s"establishing connection with impala") 
     impala_connection.StartConnection()
+  }
+  //from 2.2 --> start HIVE Connection
+  if (!TestPlanMode) {
+    if (GlobalSettings.ValidPath(GlobalSettings.HIVE_Setting, this.Environment)) {
+      logMessageInfo(s"establishing connection with JDBC HIVE")
+      HIVE_connection.StartConnection()
+    } else {
+      logMessageWarn(s"can't establish connection with JDBC HIVE (HIVE_Setting's missing)")
+    }
   }
   
   val spark: SparkSession = if (!TestPlanMode & LocalSparkSession == null) 
@@ -961,7 +986,11 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     if (numPartitions != null && numPartitions > 0)
       SQL_DF = SQL_DF.repartition(numPartitions)      
       
-    if (this.DebugMode) SQL_DF.show()
+    
+    if (this.DebugMode) {
+      this.logMessageDebug(s"alias: ${Alias}")
+      SQL_DF.show()
+    }
     //Change alias name
     SQL_DF.createOrReplaceTempView(Alias)         //crea vista sql
 

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -21,6 +21,9 @@ class huemul_GlobalPath() extends Serializable {
     val CONTROL_Setting: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     val IMPALA_Setting: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     
+    //from 2.2 --> add HIVE connect
+    val HIVE_Setting: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
+    
     //RAW
     val RAW_SmallFiles_Path: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
     val RAW_BigFiles_Path: ArrayBuffer[huemul_KeyValuePath] = new ArrayBuffer[huemul_KeyValuePath]()
@@ -70,6 +73,23 @@ class huemul_GlobalPath() extends Serializable {
     //from 2.1
     //set > 1 to cache hive metadata
     var HIVE_HourToUpdateMetadata: Integer = 0
+    
+    //FROM 2.2
+    //Add Hbase available
+    private var _HBase_available: Boolean = false
+    def getHBase_available(): Boolean = {return _HBase_available}
+    def setHBase_available() {
+      _HBase_available = true
+    }
+    /*
+    private var _HBase_formatTable: String = "org.apache.spark.sql.execution.datasources.hbase"
+    def setHBase_formatTable(value: String) {
+      _HBase_formatTable = value
+    }
+    def getHBase_formatTable(): String = {return _HBase_formatTable}
+    * 
+    */
+    
     
     /**
      Returns true if path has value, otherwise return false

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -54,8 +54,10 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
   var Control_Start_dt: Calendar = Calendar.getInstance()
   var Control_Stop_dt: Calendar = null
   val Control_Error: huemul_ControlError = new huemul_ControlError(huemulBigDataGov)
-  val Control_Params: scala.collection.mutable.ListBuffer[huemul_LibraryParams] = new scala.collection.mutable.ListBuffer[huemul_LibraryParams]() 
+  val Control_Params: scala.collection.mutable.ListBuffer[huemul_LibraryParams] = new scala.collection.mutable.ListBuffer[huemul_LibraryParams]()
+  
   private var LocalIdStep: String = ""
+  def getStepId: String = return LocalIdStep 
   private var Step_IsDQ: Boolean = false
   private var AdditionalParamsInfo: String = ""
   
@@ -137,7 +139,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
       if (!Ejec.IsError && ApplicationInUse == null)
         ContinueInLoop = false
       else {      
-        if (huemulBigDataGov.DebugMode) phuemulBigDataGov.logMessageDebug(s"waiting for Singleton... (class: $Control_ClassName, appId: ${huemulBigDataGov.IdApplication} )")
+        phuemulBigDataGov.logMessageDebug(s"waiting for Singleton... (class: $Control_ClassName, appId: ${huemulBigDataGov.IdApplication} )")
         //if has error, verify other process still alive
         if (NumCycle == 1) //First cicle don't wait
           Thread.sleep(10000)

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_JDBCResult.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_JDBCResult.scala
@@ -93,6 +93,7 @@ class huemul_JDBCProperties(huemulBigDataGob: huemul_BigDataGovernance,  connect
     var Result: huemul_JDBCResult = new huemul_JDBCResult()
     
     var i = 0
+    if (connection == null) sys.error("error JDBC connection failed")
     while (i<=2 && connection.isClosed()) {
       huemulBigDataGob.logMessageWarn("CONTROL connection closed, trying to establish new connection")
       StartConnection()
@@ -221,6 +222,7 @@ class huemul_JDBCProperties(huemulBigDataGob: huemul_BigDataGovernance,  connect
     //val url = ""
    
     var i = 0
+    if (connection == null) sys.error("error JDBC connection failed")
     while (i<=2 && connection.isClosed()) {
       huemulBigDataGob.logMessageWarn("CONTROL connection closed, trying to establish new connection")
       StartConnection()

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_InternalTableType.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_InternalTableType.scala
@@ -1,0 +1,6 @@
+package com.huemulsolutions.bigdata.tables
+
+object huemulType_InternalTableType extends Enumeration {
+  type huemulType_InternalTableType = Value
+  val Normal, DQ, OldValueTrace = Value
+}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_StorageType.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_StorageType.scala
@@ -2,5 +2,5 @@ package com.huemulsolutions.bigdata.tables
 
 object huemulType_StorageType extends Enumeration {
   type huemulType_StorageType = Value
-  val PARQUET, ORC, AVRO = Value
+  val PARQUET, ORC, AVRO, HBASE = Value
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_Tables.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemulType_Tables.scala
@@ -6,7 +6,3 @@ object huemulType_Tables extends Enumeration {
 }
 
 
-object huemulType_InternalTableType extends Enumeration {
-  type huemulType_InternalTableType = Value
-  val Normal, DQ, OldValueTrace = Value
-}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Columns.scala
@@ -454,4 +454,33 @@ class huemul_Columns(param_DataType: DataType
     this.SQLForInsert = SQLForInsert
   }
   
+  //from 2.2 --> add setting to HBase
+  private var _hive_df: String = "default"
+  private var _hive_col: String = null
+  
+  /**
+   * Define family and column name on HBase Tables 
+   */
+  def setHBaseCatalogMapping(df: String, col: String = null): huemul_Columns = {
+    _hive_df = df
+    _hive_col = col
+    this
+  }
+  
+  def getHBaseCatalogFamily(): String = {return _hive_df}
+  def getHBaseCatalogColumn(): String = {return if (_hive_col == null) get_MyName() else _hive_col}
+  
+  def getHBaseDataType(): String = {
+    return if (DataType == DataTypes.StringType) "string"
+      else if (DataType == DataTypes.IntegerType) "int"
+      else if (DataType == DataTypes.ShortType) "smallint"
+      else if (DataType == DataTypes.BooleanType) "boolean"
+      else if (DataType == DataTypes.DoubleType) "double"
+      else if (DataType == DataTypes.FloatType) "float"
+      else if (DataType == DataTypes.LongType) "bigint"
+      else if (DataType == DataTypes.ShortType) "tinyint"
+      else if (DataType == DataTypes.BinaryType) "binary"
+      else "string"
+        
+  }
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -105,7 +105,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   def getStorageType: huemulType_StorageType = {return _StorageType}
   private var _StorageType : huemulType_StorageType = null
   
-  val _StorageType_OldValueTrace: String = "parquet"  //csv, json, parquet
+  val _StorageType_OldValueTrace: String = "parquet"  //csv, json, parquet, orc
   /**
     Table description
    */
@@ -491,6 +491,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       raiseError(s"huemul_Table Error: PartitionField should be defined if TableType is Transactional",1035)
     else if (this._TableType != huemulType_Tables.Transaction && _PartitionField != "")
       raiseError(s"huemul_Table Error: PartitionField shouldn't be defined if TableType is ${this._TableType}",1036)
+      
+    //from 2.2 --> validate tableType with Format
+    if (this._TableType == huemulType_Tables.Transaction && !(this._StorageType == huemulType_StorageType.PARQUET || this._StorageType == huemulType_StorageType.ORC))
+      raiseError(s"huemul_Table Error: Transaction Tables only available with PARQUET or ORC StorageType ",1057)
       
     if (this._DataBase == null)
       raiseError(s"huemul_Table Error: DataBase must be defined",1037)
@@ -1641,7 +1645,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                    """PARTITIONED BY (MDM_columnName STRING)
                                      STORED AS PARQUET""" 
                                   }
+                                  else if (_StorageType_OldValueTrace == "orc") {
+                                   """PARTITIONED BY (MDM_columnName STRING)
+                                     STORED AS ORC""" 
                                   }
+                                 }
                                  LOCATION '${getFullNameWithPath_OldValueTrace()}'"""
                                   //${if (_StorageType_OldValueTrace == "csv") {s"""
                                   //TBLPROPERTIES("timestamp.formats"="yyyy-MM-dd'T'HH:mm:ss.SSSZ")"""}}"""
@@ -2261,14 +2269,14 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         }
         
         if (this.getNumPartitions == null || this.getNumPartitions <= 0)
-          DFTempCopy.write.mode(SaveMode.Overwrite).format("parquet").save(tempPath)
+          DFTempCopy.write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(tempPath)     //2.2 -> this._StorageType.toString() instead of "parquet"
         else
-          DFTempCopy.repartition(this.getNumPartitions).write.mode(SaveMode.Overwrite).format("parquet").save(tempPath)
+          DFTempCopy.repartition(this.getNumPartitions).write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(tempPath)   //2.2 -> this._StorageType.toString() instead of "parquet"
         DFTempCopy.unpersist()
        
         //Open temp file
         if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"open temp old df: $tempPath ")
-        val DFTempOpen = huemulBigDataGov.spark.read.parquet(tempPath)        
+        val DFTempOpen = huemulBigDataGov.spark.read.format(this._StorageType.toString()).load(tempPath)  //2.2 --> read.format(this._StorageType.toString()).load(tempPath)    instead of  read.parquet(tempPath)   
         DFTempOpen.createOrReplaceTempView(TempAlias)        
       } else {
           huemulBigDataGov.logMessageInfo(s"create empty dataframe because ${this.internalGetTable(huemulType_InternalTableType.Normal)} does not exist")

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -5,28 +5,36 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
+
 import java.lang.Long
 import scala.collection.mutable._
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.permission.FsPermission
 import huemulType_Tables._
 import huemulType_StorageType._
-import com.huemulsolutions.bigdata._
+//import com.huemulsolutions.bigdata._
 import com.huemulsolutions.bigdata.dataquality.huemul_DataQuality
 import com.huemulsolutions.bigdata.dataquality.huemul_DataQualityResult
 import com.huemulsolutions.bigdata.common._
-import com.huemulsolutions.bigdata.control._
-import com.sun.xml.internal.ws.api.pipe.NextAction
-import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel
-import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification
-import com.huemulsolutions.bigdata.dataquality.huemul_DQRecord
+import com.huemulsolutions.bigdata.control.huemul_Control
 import com.huemulsolutions.bigdata.control.huemulType_Frequency
 import com.huemulsolutions.bigdata.control.huemulType_Frequency._
-import com.huemulsolutions.bigdata.tables.huemulType_Tables.huemulType_Tables
+
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel._
+//import com.huemulsolutions.bigdata.dataquality.huemulType_DQQueryLevel.huemulType_DQQueryLevel
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification
+import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification._
+//import com.huemulsolutions.bigdata.dataquality.huemulType_DQNotification.huemulType_DQNotification
+import com.huemulsolutions.bigdata.dataquality.huemul_DQRecord
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency.huemulType_Frequency
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency.huemulType_Frequency
+//import com.huemulsolutions.bigdata.tables.huemulType_Tables.huemulType_Tables
 import com.huemulsolutions.bigdata.tables.huemulType_InternalTableType._
 import com.huemulsolutions.bigdata.datalake.huemul_DataLake
+//import com.huemulsolutions.bigdata.control.huemulType_Frequency.huemulType_Frequency
 
-//import com.sun.imageio.plugins.jpeg.DQTMarkerSegment
 
 
 class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_Control) extends huemul_TableDQ with Serializable  {
@@ -67,6 +75,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   def setPK_externalCode(value: String) {
     _PK_externalCode = value  
   }
+  
+  private def _storageType_default = huemulType_StorageType.PARQUET
   /**
    Save DQ Result to disk, only if DQ_SaveErrorDetails in GlobalPath is true
    */
@@ -105,7 +115,50 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   def getStorageType: huemulType_StorageType = {return _StorageType}
   private var _StorageType : huemulType_StorageType = null
   
-  val _StorageType_OldValueTrace: String = "parquet"  //csv, json, parquet, orc
+  
+  /**
+   Type of Persistent storage (parquet, csv, json) for DQ
+   */
+  def setStorageType_DQResult(value: huemulType_StorageType) {
+    if (_StorageType_DQResult == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for DQ Table", 1061)
+      
+    if (DefinitionIsClose)
+      this.raiseError("You can't change value of StorageType_DQResult, definition is close", 1033)
+    else
+      _StorageType_DQResult = value
+  }
+  def getStorageType_DQResult: huemulType_StorageType = {
+    if (_StorageType_DQResult == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for DQ Table", 1061)
+    return   if (_StorageType_DQResult != null) _StorageType_DQResult
+        else if (_StorageType_DQResult == null && getStorageType == huemulType_StorageType.HBASE ) _storageType_default  
+        else getStorageType
+  }
+  private var _StorageType_DQResult : huemulType_StorageType = null
+  
+  /**
+   Type of Persistent storage (parquet, csv, json) for DQ
+   */
+  def setStorageType_OldValueTrace(value: huemulType_StorageType) {
+    if (_StorageType_OldValueTrace == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for OldValueTraceTable", 1063)
+      
+    if (DefinitionIsClose)
+      this.raiseError("You can't change value of StorageType_OldValueTrace, definition is close", 1033)
+    else
+      _StorageType_OldValueTrace = value
+  }
+  def getStorageType_OldValueTrace: huemulType_StorageType = {
+    if (_StorageType_OldValueTrace == huemulType_StorageType.HBASE)
+      raiseError("huemul_Table Error: HBase is not available for OldValueTraceTable", 1063)
+    return   if (_StorageType_OldValueTrace != null) _StorageType_OldValueTrace
+        else if (_StorageType_OldValueTrace == null && getStorageType == huemulType_StorageType.HBASE ) _storageType_default  
+        else getStorageType    
+  }
+  private var _StorageType_OldValueTrace : huemulType_StorageType = null
+  
+  //val _StorageType_OldValueTrace: String = "parquet"  //csv, json, parquet, orc
   /**
     Table description
    */
@@ -163,8 +216,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     else
       _LocalPath = value
   }
-  def getLocalPath: String = {return _LocalPath}
   private var _LocalPath   : String= ""
+  def getLocalPath: String = {return if (_LocalPath == null) "null/"
+                                     else if (_LocalPath.takeRight(1) != "/") _LocalPath.concat("/")
+                                     else _LocalPath }
+  
   
   def setGlobalPaths(value: ArrayBuffer[huemul_KeyValuePath]) {
     if (DefinitionIsClose)
@@ -215,7 +271,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   def getFrequency: huemulType_Frequency = {return _Frequency}
   
   /**
-   * SaveDQErrorOnce: true (default value) to save DQ result to disk only once (all together)
+   * SaveDQErrorOnce: false (default value) to save DQ result to disk only once (all together)
    * false to save DQ result to disk independently (each DQ error or warning)
   */
   def setSaveDQErrorOnce(value: Boolean) {
@@ -224,7 +280,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     else
       _SaveDQErrorOnce = value
   }
-  private var _SaveDQErrorOnce: Boolean = true
+  private var _SaveDQErrorOnce: Boolean = false
   def getSaveDQErrorOnce: Boolean = {return _SaveDQErrorOnce}
   
   
@@ -308,19 +364,22 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    ******************************************************************************** */
   
   
-  val MDM_newValue = new huemul_Columns (StringType, true, "New value updated in table", false)
-  val MDM_oldValue = new huemul_Columns (StringType, true, "Old value", false)
-  val MDM_AutoInc = new huemul_Columns (LongType, true, "auto incremental for version control", false)
-  val processExec_id = new huemul_Columns (StringType, true, "Process Execution Id (control model)", false)
+  val MDM_newValue = new huemul_Columns (StringType, true, "New value updated in table", false).setHBaseCatalogMapping("loginfo")
+  val MDM_oldValue = new huemul_Columns (StringType, true, "Old value", false).setHBaseCatalogMapping("loginfo")
+  val MDM_AutoInc = new huemul_Columns (LongType, true, "auto incremental for version control", false).setHBaseCatalogMapping("loginfo")
+  val processExec_id = new huemul_Columns (StringType, true, "Process Execution Id (control model)", false).setHBaseCatalogMapping("loginfo")
   
-  val MDM_fhNew = new huemul_Columns (TimestampType, true, "Fecha/hora cuando se insertaron los datos nuevos", false)
-  val MDM_ProcessNew = new huemul_Columns (StringType, false, "Nombre del proceso que insertó los datos", false)
-  val MDM_fhChange = new huemul_Columns (TimestampType, false, "fecha / hora de último cambio de valor en los campos de negocio", false)
-  val MDM_ProcessChange = new huemul_Columns (StringType, false, "Nombre del proceso que cambió los datos", false)
-  val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false)
-  val MDM_hash = new huemul_Columns (StringType, true, "Valor hash de los datos de la tabla", false)
+  val MDM_fhNew = new huemul_Columns (TimestampType, true, "Fecha/hora cuando se insertaron los datos nuevos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_ProcessNew = new huemul_Columns (StringType, false, "Nombre del proceso que insertó los datos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_fhChange = new huemul_Columns (TimestampType, false, "fecha / hora de último cambio de valor en los campos de negocio", false).setHBaseCatalogMapping("loginfo")
+  val MDM_ProcessChange = new huemul_Columns (StringType, false, "Nombre del proceso que cambió los datos", false).setHBaseCatalogMapping("loginfo")
+  val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false).setHBaseCatalogMapping("loginfo")
+  val MDM_hash = new huemul_Columns (StringType, true, "Valor hash de los datos de la tabla", false).setHBaseCatalogMapping("loginfo")
   
-  val MDM_columnName = new huemul_Columns (StringType, true, "Column Name", false)
+  val MDM_columnName = new huemul_Columns (StringType, true, "Column Name", false).setHBaseCatalogMapping("loginfo")
+  
+  //from 2.2 --> add rowKey compatibility with HBase
+  val hs_rowKey = new huemul_Columns (StringType, true, "Concatenated PK", false).setHBaseCatalogMapping("loginfo")
   
   var AdditionalRowsForDistint: String = ""
   private var DefinitionIsClose: Boolean = false
@@ -341,36 +400,36 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    * Get Fullpath hdfs = GlobalPaths + LocalPaths + TableName  
    */
   def getFullNameWithPath() : String = {
-    return globalPath + _LocalPath + TableName
+    return globalPath + getLocalPath + TableName
   }
   
   /**
    * Get Fullpath hdfs for DQ results = GlobalPaths + DQError_Path + TableName + "_dq"
    */
   def getFullNameWithPath_DQ() : String = {
-    return this.getPath(huemulBigDataGov.GlobalSettings.DQError_Path) + this.getDataBase(this._DataBase) + '/' + _LocalPath + TableName + "_dq"
+    return this.getPath(huemulBigDataGov.GlobalSettings.DQError_Path) + this.getDataBase(this._DataBase) + '/' + getLocalPath + TableName + "_dq"
   }
   
   /**
    * Get Fullpath hdfs for _oldvalue results = GlobalPaths + DQError_Path + TableName + "_oldvalue"
    */
   def getFullNameWithPath_OldValueTrace() : String = {
-    return this.getPath(huemulBigDataGov.GlobalSettings.MDM_OldValueTrace_Path) + this.getDataBase(this._DataBase) + '/' + _LocalPath + TableName + "_oldvalue"
+    return this.getPath(huemulBigDataGov.GlobalSettings.MDM_OldValueTrace_Path) + this.getDataBase(this._DataBase) + '/' + getLocalPath + TableName + "_oldvalue"
   }
   
    /**
    * Get Fullpath hdfs for backpu  = Backup_Path + database + TableName + "_backup"
    */
   def getFullNameWithPath_Backup(control_id: String) : String = {
-    return this.getPath(huemulBigDataGov.GlobalSettings.MDM_Backup_Path) + this.getDataBase(this._DataBase) + '/' + _LocalPath + 'c' + control_id + '/' + TableName + "_backup"
+    return this.getPath(huemulBigDataGov.GlobalSettings.MDM_Backup_Path) + this.getDataBase(this._DataBase) + '/' + getLocalPath + 'c' + control_id + '/' + TableName + "_backup"
   }
   
   def getFullNameWithPath2(ManualEnvironment: String) : String = {
-    return globalPath(ManualEnvironment) + _LocalPath + TableName
+    return globalPath(ManualEnvironment) + getLocalPath + TableName
   }
     
   def getFullPath() : String = {
-    return globalPath + _LocalPath 
+    return globalPath + getLocalPath 
   }
   
   
@@ -402,6 +461,150 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   def getTable_OldValueTrace(): String = {
     return internalGetTable(huemulType_InternalTableType.OldValueTrace)
   }
+  
+  //new from 2.2
+  /**
+   * Define HBase Table and namespace 
+   */
+  private var _hbase_namespace: String = null
+  private var _hbase_tableName: String = null
+  def setHBaseTableName(namespace: String, tableName: String = null) {
+    _hbase_namespace = namespace
+    _hbase_tableName = tableName
+  }
+  
+  def getHBaseNamespace(internalTableType: huemulType_InternalTableType): String = {
+    var valueName: String = null
+    if (internalTableType == huemulType_InternalTableType.DQ) {
+      valueName = getDataBase(huemulBigDataGov.GlobalSettings.DQError_DataBase)
+    } else if (internalTableType == huemulType_InternalTableType.Normal) { 
+      valueName = if ( _hbase_namespace == null) this.getDataBase(this._DataBase) else _hbase_namespace
+    } else if (internalTableType == huemulType_InternalTableType.OldValueTrace) { 
+      valueName = getDataBase(huemulBigDataGov.GlobalSettings.MDM_OldValueTrace_DataBase)
+    } else {
+      raiseError(s"huemul_Table Error: Type '${internalTableType}' doesn't exist in InternalGetTable method (getHBaseNamespace)", 1059)
+    }
+    
+     return valueName
+    
+  }
+  
+  def getHBaseTableName(internalTableType: huemulType_InternalTableType): String = {
+    var valueName: String = if (_hbase_tableName == null) this.TableName else _hbase_tableName
+    if (internalTableType == huemulType_InternalTableType.DQ) {
+      valueName =  valueName + "_dq"
+    } else if (internalTableType == huemulType_InternalTableType.Normal) { 
+      valueName = valueName
+    } else if (internalTableType == huemulType_InternalTableType.OldValueTrace) { 
+      valueName = valueName + "_oldvalue"
+    } else {
+      raiseError(s"huemul_Table Error: Type '${internalTableType}' doesn't exist in InternalGetTable method (getHBaseTableName)", 1060)
+    }
+     
+    return valueName
+  }
+  
+  /**
+   * get Catalog for HBase mapping
+   */
+  
+  def getHBaseCatalog(tableType: huemulType_InternalTableType): String = {
+
+    //create fields
+    var fields: String = s""""${if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey"}":{"cf":"rowkey","col":"key","type":"string"} """
+    getALLDeclaredFields().filter { x => x.setAccessible(true) 
+                x.get(this).isInstanceOf[huemul_Columns] 
+    } foreach { x =>
+      x.setAccessible(true)
+      var dataField = x.get(this).asInstanceOf[huemul_Columns]
+      
+      if (!(dataField.getIsPK && _numPKColumns == 1)) {        
+        //fields = fields + s""", \n "${x.getName}":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}","type":"${dataField.getHBaseDataType()}"} """
+        fields = fields + s""", \n "${x.getName}":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}","type":"${dataField.getHBaseDataType()}"} """
+      
+        if (tableType != huemulType_InternalTableType.OldValueTrace) {
+          if (dataField.getMDM_EnableOldValue)
+            fields = fields + s""", \n "${x.getName}_old":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}_old","type":"${dataField.getHBaseDataType()}"} """
+          if (dataField.getMDM_EnableDTLog)
+            fields = fields + s""", \n "${x.getName}_fhChange":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}_fhChange","type":"string"} """
+          if (dataField.getMDM_EnableProcessLog)
+            fields = fields + s""", \n "${x.getName}_ProcessLog":{"cf":"${dataField.getHBaseCatalogFamily()}","col":"${dataField.getHBaseCatalogColumn()}_ProcessLog","type":"string"} """
+        }
+        
+      }
+    }
+    
+    //create struct
+    var result = s"""{
+        "table":{"namespace":"${getHBaseNamespace(tableType)}", "name":"${getHBaseNamespace(tableType)}:${getHBaseTableName(tableType)}"},
+        "rowkey":"key",
+        "columns":{${fields}
+         }
+      }""".stripMargin
+    
+    return result
+  }
+  
+  
+  /**
+   * get Catalog for HBase mapping
+   */
+  def getHBaseCatalogForHIVE(tableType: huemulType_InternalTableType): String = {
+   //WARNING!!! Any changes you make to this code, repeat it in getColumns_CreateTable
+    //create fields
+    var fields: String = s":key"
+    getALLDeclaredFields().filter { x => x.setAccessible(true) 
+                x.get(this).isInstanceOf[huemul_Columns] 
+    } foreach { x =>
+      x.setAccessible(true)
+      var dataField = x.get(this).asInstanceOf[huemul_Columns]
+      
+      if (!(dataField.getIsPK && _numPKColumns == 1) && (x.getName.toLowerCase() != "hs_rowKey".toLowerCase())) {        
+        
+        if (tableType == huemulType_InternalTableType.DQ) {
+          //create StructType
+          if ("dq_control_id".toUpperCase() != x.getName.toUpperCase()) {
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}#b"""
+          }
+        }
+        else if (tableType == huemulType_InternalTableType.OldValueTrace) {
+          //create StructType MDM_columnName
+          if ("MDM_columnName".toUpperCase() != x.getName.toUpperCase()) {
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}#b"""
+          }
+        }
+        else {
+          //create StructType
+          fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}${if (dataField.DataType == TimestampType || dataField.DataType == DateType || dataField.DataType == DecimalType || dataField.DataType.typeName.toLowerCase().contains("decimal")) "" else "#b"}"""
+          
+        }
+        
+        if (tableType != huemulType_InternalTableType.OldValueTrace) {
+          if (dataField.getMDM_EnableOldValue)
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_old${if (dataField.DataType == TimestampType || dataField.DataType == DateType || dataField.DataType == DecimalType || dataField.DataType.typeName.toLowerCase().contains("decimal") ) "" else "#b"}"""
+          if (dataField.getMDM_EnableDTLog) 
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_fhChange"""
+          if (dataField.getMDM_EnableProcessLog)
+            fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}_ProcessLog#b"""
+        }
+        
+        
+      }
+    }
+    
+    
+    return fields
+  }
+ 
+  
+  //get PK for HBase Tables rowKey 
+  private var _HBase_rowKeyCalc: String = ""
+  private var _HBase_PKColumn: String = ""
+  
+  private var _numPKColumns: Int = 0
+  
+  
+  
   
   
   private def internalGetTable(internalTableType: huemulType_InternalTableType, withDataBase: Boolean = true): String = {
@@ -482,8 +685,14 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     if (this._LocalPath == null)
       raiseError(s"huemul_Table Error: LocalPath must be defined",1001)
       
-    if (this._StorageType == null)
+    if (this.getStorageType == null)
       raiseError(s"huemul_Table Error: StorageType must be defined",1002)
+      
+    if (this.getStorageType_DQResult == null)
+      raiseError(s"huemul_Table Error: HBase is not available for DQ Table",1061)
+      
+    if (this.getStorageType_OldValueTrace == null)
+      raiseError(s"huemul_Table Error: HBase is not available for OldValueTraceTable",1063)
       
     if (this._TableType == null)
       raiseError(s"huemul_Table Error: TableType must be defined",1034)
@@ -493,20 +702,27 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       raiseError(s"huemul_Table Error: PartitionField shouldn't be defined if TableType is ${this._TableType}",1036)
       
     //from 2.2 --> validate tableType with Format
-    if (this._TableType == huemulType_Tables.Transaction && !(this._StorageType == huemulType_StorageType.PARQUET || this._StorageType == huemulType_StorageType.ORC))
+    if (this._TableType == huemulType_Tables.Transaction && !(this.getStorageType == huemulType_StorageType.PARQUET || this.getStorageType == huemulType_StorageType.ORC))
       raiseError(s"huemul_Table Error: Transaction Tables only available with PARQUET or ORC StorageType ",1057)
+      
+    //Fron 2.2 --> validate tableType HBASE and turn on globalSettings
+    if (this.getStorageType == huemulType_StorageType.HBASE && !huemulBigDataGov.GlobalSettings.getHBase_available)
+      raiseError(s"huemul_Table Error: StorageType is set to HBASE, requires invoke HBase_available in globalSettings  ",1058)
       
     if (this._DataBase == null)
       raiseError(s"huemul_Table Error: DataBase must be defined",1037)
     if (this._Frequency == null)
       raiseError(s"huemul_Table Error: Frequency must be defined",1047)
       
-    if (this._SaveBackup == true && this._TableType == huemulType_Tables.Transaction)
+    if (this.getSaveBackup == true && this.getTableType == huemulType_Tables.Transaction)
       raiseError(s"huemul_Table Error: SaveBackup can't be true for transactional tables",1054)
         
       
     var PartitionFieldValid: Boolean = false
-      
+    var comaPKConcat = ""
+    
+    _numPKColumns = 0
+    _HBase_rowKeyCalc = ""
     getALLDeclaredFields().filter { x => x.setAccessible(true) 
                 x.get(this).isInstanceOf[huemul_Columns] || x.get(this).isInstanceOf[huemul_DataQuality] || x.get(this).isInstanceOf[huemul_Table_Relationship]  
     } foreach { x =>
@@ -541,6 +757,15 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         
         if (this.getTableType == huemulType_Tables.Transaction && DataField.get_MyName().toUpperCase() == this.getPartitionField.toUpperCase())
           PartitionFieldValid = true
+          
+        //from 2.2 --> get concatenaded key for HBase
+        if (DataField.getIsPK && getStorageType == huemulType_StorageType.HBASE) {
+          _HBase_rowKeyCalc += s"${comaPKConcat}'[', ${if (DataField.DataType == StringType) DataField.get_MyName() else s"CAST(${DataField.get_MyName()} AS STRING)" },']'"
+          comaPKConcat = ","
+          _HBase_PKColumn = DataField.get_MyName()
+          _numPKColumns += 1
+        }
+            
       }
       
       //Nombre de DQ      
@@ -563,6 +788,14 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         //TODO: Validate FK Setting
         
       }
+    }
+    
+    //from 2.2 --> set _HBase_rowKey for hBase Tables
+    if (getStorageType == huemulType_StorageType.HBASE) {
+      if (_numPKColumns == 1)
+        _HBase_rowKeyCalc = _HBase_PKColumn
+      else 
+        _HBase_rowKeyCalc = s"concat(${_HBase_rowKeyCalc})"
     }
     
     
@@ -619,7 +852,12 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         b = b.filter { x => x.getName != "MDM_columnName" && x.getName != "MDM_newValue" && x.getName != "MDM_oldValue" && x.getName != "MDM_AutoInc" && x.getName != "processExec_id"  }
         
         if (this._TableType == huemulType_Tables.Transaction) 
-          b = b.filter { x => x.getName != "MDM_ProcessChange" && x.getName != "MDM_fhChange" && x.getName != "MDM_StatusReg"  }   
+          b = b.filter { x => x.getName != "MDM_ProcessChange" && x.getName != "MDM_fhChange" && x.getName != "MDM_StatusReg"   }
+        
+        //       EXCLUDE FOR PARQUET, ORC, ETC             OR            EXCLUDE FOR HBASE AND NUM PKs == 1
+        if (getStorageType != huemulType_StorageType.HBASE || (getStorageType == huemulType_StorageType.HBASE && _numPKColumns == 1) )
+          b = b.filter { x => x.getName != "hs_rowKey"  }
+        
       }
       
       
@@ -642,6 +880,22 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
 
     
     return c
+  }
+  
+  /**
+   * Get all declared fields from class, transform to huemul_Columns
+   */
+  private def getALLDeclaredFields_forHBase(allDeclaredFields: Array[java.lang.reflect.Field]) : Array[(java.lang.reflect.Field, String, String, DataType)] = {
+       
+    val result = allDeclaredFields.filter { x => x.setAccessible(true)
+                                      x.get(this).isInstanceOf[huemul_Columns] }.map { x =>     
+      //Get field
+      x.setAccessible(true)
+      var Field = x.get(this).asInstanceOf[huemul_Columns]
+      (x,Field.getHBaseCatalogFamily(), Field.getHBaseCatalogColumn(), Field.DataType)
+    }
+    
+    return result
   }
   
   //private var _SQL_OldValueFullTrace_DF: DataFrame = null 
@@ -802,14 +1056,28 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    Create schema from DataDef Definition
    */
   private def getColumns_CreateTable(ForHive: Boolean = false, tableType: huemulType_InternalTableType = huemulType_InternalTableType.Normal ): String = {
+    //WARNING!!! Any changes you make to this code, repeat it in getHBaseCatalogForHIVE
     val fieldList = getALLDeclaredFields(false,true,tableType)
     val NumFields = fieldList.filter { x => x.setAccessible(true)
                                       x.get(this).isInstanceOf[huemul_Columns] }.length
     
+    
     var ColumnsCreateTable : String = ""
     var coma: String = ""
+    
+    //for HBase, add hs_rowKey as Key column
+    if (getStorageType == huemulType_StorageType.HBASE && _numPKColumns > 1) {
+      fieldList.filter { x => x.getName == "hs_rowKey" }.foreach { x =>
+        var Field = x.get(this).asInstanceOf[huemul_Columns]
+        var DataTypeLocal = Field.DataType.sql
+      
+        ColumnsCreateTable += s"$coma${x.getName} ${DataTypeLocal} \n"
+        coma = ","
+      }
+    }                                      
+    
     fieldList.filter { x => x.setAccessible(true)
-                                      x.get(this).isInstanceOf[huemul_Columns] }
+                                      x.get(this).isInstanceOf[huemul_Columns] && x.getName != "hs_rowKey" }
     .foreach { x =>     
       //Get field
       var Field = x.get(this).asInstanceOf[huemul_Columns]
@@ -1021,7 +1289,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           StringSQL_ActionType = s" case when Old.${x.getName} is null then 'NEW' when ${NewColumnCast} is null then 'EQUAL' else 'UPDATE' END as ___ActionType__  "
       } else {
         //¿column exist in DataFrame?
-        val columnExist = !(OfficialColumns.filter { y => y.name == x.getName}.length == 0)
+        val columnExist = !(OfficialColumns.filter { y => y.name.toLowerCase() == x.getName.toLowerCase()}.length == 0)
         
         //String for new DataFrame fulljoin
         if (columnExist){
@@ -1055,19 +1323,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         }
       
         if (Field.getMDM_EnableOldValue){
-          if (OfficialColumns.filter { y => y.name == s"${x.getName}_old"}.length == 0) //no existe columna en dataframe
+          if (OfficialColumns.filter { y => y.name.toLowerCase() == s"${x.getName}_old".toLowerCase()}.length == 0) //no existe columna en dataframe
             StringSQL_LeftJoin += s",CAST(null AS ${Field.DataType.sql}) as old_${x.getName}_old \n"
           else //existe columna en dataframe
             StringSQL_LeftJoin += s",CAST(old.${x.getName}_old AS ${Field.DataType.sql}) as old_${x.getName}_old \n"
         }
         if (Field.getMDM_EnableDTLog){
-          if (OfficialColumns.filter { y => y.name == s"${x.getName}_fhChange"}.length == 0) //no existe columna en dataframe
+          if (OfficialColumns.filter { y => y.name.toLowerCase() == s"${x.getName}_fhChange".toLowerCase()}.length == 0) //no existe columna en dataframe
             StringSQL_LeftJoin += s",CAST(null AS TimeStamp) as old_${x.getName}_fhChange \n"
           else //existe columna en dataframe
             StringSQL_LeftJoin += s",CAST(old.${x.getName}_fhChange AS TimeStamp) as old_${x.getName}_fhChange \n"
         }
         if (Field.getMDM_EnableProcessLog){
-          if (OfficialColumns.filter { y => y.name == s"${x.getName}_ProcessLog"}.length == 0) //no existe columna en dataframe
+          if (OfficialColumns.filter { y => y.name.toLowerCase() == s"${x.getName}_ProcessLog".toLowerCase()}.length == 0) //no existe columna en dataframe
             StringSQL_LeftJoin += s",CAST(null AS STRING) as old_${x.getName}_ProcessLog \n"
           else //existe columna en dataframe
             StringSQL_LeftJoin += s",CAST(old.${x.getName}_ProcessLog AS STRING) as old_${x.getName}_ProcessLog \n"
@@ -1162,7 +1430,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           StringSQL_ActionType = s" case when Old.${x.getName} is null then 'NEW' when ${NewColumnCast} is null then ${if (isDelete) "'DELETE'" else "'EQUAL'"} else ${if (isUpdate) "'UPDATE'" else "'EQUAL'"} END as ___ActionType__  "
       } else {
         //¿column exist in DataFrame?
-        val columnExist = !(OfficialColumns.filter { y => y.name == x.getName}.length == 0)
+        val columnExist = !(OfficialColumns.filter { y => y.name.toLowerCase() == x.getName.toLowerCase()}.length == 0)
         
         //String for new DataFrame fulljoin
         if (columnExist)
@@ -1194,19 +1462,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         }
       
         if (Field.getMDM_EnableOldValue){
-          if (OfficialColumns.filter { y => y.name == s"${x.getName}_old"}.length == 0) //no existe columna en dataframe
+          if (OfficialColumns.filter { y => y.name.toLowerCase() == s"${x.getName}_old".toLowerCase()}.length == 0) //no existe columna en dataframe
             StringSQL_FullJoin += s",CAST(null AS ${Field.DataType.sql}) as old_${x.getName}_old \n"
           else //existe columna en dataframe
             StringSQL_FullJoin += s",CAST(old.${x.getName}_old AS ${Field.DataType.sql}) as old_${x.getName}_old \n"
         }
         if (Field.getMDM_EnableDTLog){
-          if (OfficialColumns.filter { y => y.name == s"${x.getName}_fhChange"}.length == 0) //no existe columna en dataframe
+          if (OfficialColumns.filter { y => y.name.toLowerCase() == s"${x.getName}_fhChange".toLowerCase()}.length == 0) //no existe columna en dataframe
             StringSQL_FullJoin += s",CAST(null AS TimeStamp) as old_${x.getName}_fhChange \n"
           else //existe columna en dataframe
             StringSQL_FullJoin += s",CAST(old.${x.getName}_fhChange AS TimeStamp) as old_${x.getName}_fhChange \n"
         }
         if (Field.getMDM_EnableProcessLog){
-          if (OfficialColumns.filter { y => y.name == s"${x.getName}_ProcessLog"}.length == 0) //no existe columna en dataframe
+          if (OfficialColumns.filter { y => y.name.toLowerCase() == s"${x.getName}_ProcessLog".toLowerCase()}.length == 0) //no existe columna en dataframe
             StringSQL_FullJoin += s",CAST(null AS STRING) as old_${x.getName}_ProcessLog \n"
           else //existe columna en dataframe
             StringSQL_FullJoin += s",CAST(old.${x.getName}_ProcessLog AS STRING) as old_${x.getName}_ProcessLog \n"
@@ -1251,7 +1519,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         
       } else {
         if (   x.getName == "MDM_fhNew" || x.getName == "MDM_ProcessNew" || x.getName == "MDM_fhChange"
-            || x.getName == "MDM_ProcessChange" || x.getName == "MDM_StatusReg" 
+            || x.getName == "MDM_ProcessChange" || x.getName == "MDM_StatusReg" || x.getName == "hs_rowKey"
             || x.getName == "MDM_hash")
           StringSQL += s"${coma}old_${x.getName}  \n"
         else {          
@@ -1302,7 +1570,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         
       } else {
         if (   x.getName == "MDM_fhNew" || x.getName == "MDM_ProcessNew" || x.getName == "MDM_fhChange"
-            || x.getName == "MDM_ProcessChange" || x.getName == "MDM_StatusReg" 
+            || x.getName == "MDM_ProcessChange" || x.getName == "MDM_StatusReg" || x.getName == "hs_rowKey" 
             || x.getName == "MDM_hash")
           StringSQL += s"${coma}old_${x.getName}  \n"
         else {          
@@ -1360,7 +1628,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       var Field = x.get(this).asInstanceOf[huemul_Columns]
            
       if (   x.getName == "MDM_fhNew" || x.getName == "MDM_ProcessNew" || x.getName == "MDM_fhChange"
-            || x.getName == "MDM_ProcessChange" || x.getName == "MDM_StatusReg" 
+            || x.getName == "MDM_ProcessChange" || x.getName == "MDM_StatusReg" || x.getName == "hs_rowKey" 
             || x.getName == "MDM_hash")
         StringSQL += s"${coma}old_${x.getName}  \n"
       else 
@@ -1406,7 +1674,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     var StringSQL: String = "SELECT "
     
     var coma: String = ""
-
+    
     //Obtiene todos los campos
     getALLDeclaredFields().filter { x => x.setAccessible(true)
                                       x.get(this).isInstanceOf[huemul_Columns]
@@ -1427,6 +1695,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         StringSQL += s" ${coma}CASE WHEN ___ActionType__ = 'UPDATE' THEN CAST(2 as Int) WHEN ___ActionType__ = 'NEW' THEN CAST(2 as Int) WHEN ___ActionType__ = 'DELETE' THEN CAST(-1 AS Int)  ELSE CAST(old_${x.getName} AS Int) END as ${x.getName} \n"
       else if (x.getName == "MDM_hash")
         StringSQL += s"${coma}MDM_hash \n"
+      else if (x.getName == "hs_rowKey"){
+        if (getStorageType == huemulType_StorageType.HBASE && _numPKColumns > 1)
+          StringSQL += s"${coma}${_HBase_rowKeyCalc} as ${x.getName} \n"
+      }
       else 
         StringSQL += s" ${coma}${x.getName}  \n"
         
@@ -1586,13 +1858,23 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       }
     }
     
-    //get from: https://docs.databricks.com/user-guide/tables.html (see Create Partitioned Table section)
-    val lCreateTableScript = s"""
-                                 CREATE EXTERNAL TABLE IF NOT EXISTS ${internalGetTable(huemulType_InternalTableType.Normal)} (${getColumns_CreateTable(true) })
-                                 ${if (_PartitionField.length() > 0) s"PARTITIONED BY (${PartitionForCreateTable})" else "" }
-                                 STORED AS ${_StorageType.toString()}                                  
-                                 LOCATION '${getFullNameWithPath()}'"""
-                                 
+    var lCreateTableScript: String = "" 
+    if (getStorageType == huemulType_StorageType.PARQUET || getStorageType == huemulType_StorageType.ORC) {
+      //get from: https://docs.databricks.com/user-guide/tables.html (see Create Partitioned Table section)
+      lCreateTableScript = s"""
+                                   CREATE EXTERNAL TABLE IF NOT EXISTS ${internalGetTable(huemulType_InternalTableType.Normal)} (${getColumns_CreateTable(true) })
+                                   ${if (_PartitionField.length() > 0) s"PARTITIONED BY (${PartitionForCreateTable})" else "" }
+                                   STORED AS ${getStorageType.toString()}                                  
+                                   LOCATION '${getFullNameWithPath()}'"""
+    } else if (getStorageType == huemulType_StorageType.HBASE)  {
+      lCreateTableScript = s"""
+                                   CREATE EXTERNAL TABLE IF NOT EXISTS ${internalGetTable(huemulType_InternalTableType.Normal)} (${getColumns_CreateTable(true) })
+                                   ROW FORMAT SERDE 'org.apache.hadoop.hive.hbase.HBaseSerDe' 
+                                   STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'
+                                   WITH SERDEPROPERTIES ("hbase.columns.mapping"="${getHBaseCatalogForHIVE(huemulType_InternalTableType.Normal)}")                                   
+                                   TBLPROPERTIES ("hbase.table.name"="${getHBaseNamespace(huemulType_InternalTableType.Normal)}:${getHBaseTableName(huemulType_InternalTableType.Normal)}")"""
+    }
+    
     if (huemulBigDataGov.DebugMode)
       huemulBigDataGov.logMessageDebug(s"Create Table sentence: ${lCreateTableScript} ")
       
@@ -1607,12 +1889,17 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     var coma_partition = ""
     var PartitionForCreateTable = s"dq_control_id STRING"
     
+    var lCreateTableScript: String = "" 
+    if (getStorageType_DQResult == huemulType_StorageType.PARQUET || getStorageType_DQResult == huemulType_StorageType.ORC) {
     //get from: https://docs.databricks.com/user-guide/tables.html (see Create Partitioned Table section)
-    val lCreateTableScript = s"""
+      lCreateTableScript = s"""
                                  CREATE EXTERNAL TABLE IF NOT EXISTS ${internalGetTable(huemulType_InternalTableType.DQ)} (${getColumns_CreateTable(true, huemulType_InternalTableType.DQ) })
                                  PARTITIONED BY (${PartitionForCreateTable})
-                                 STORED AS ${_StorageType.toString()}                                  
+                                 STORED AS ${getStorageType_DQResult.toString()}                                  
                                  LOCATION '${getFullNameWithPath_DQ()}'"""
+    } else if (getStorageType_DQResult == huemulType_StorageType.HBASE)  {
+      raiseError("huemul_Table Error: HBase is not available for DQ Table", 1061)
+    }
                                  
     if (huemulBigDataGov.DebugMode)
       huemulBigDataGov.logMessageDebug(s"Create Table sentence: ${lCreateTableScript} ")
@@ -1632,20 +1919,20 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     //get from: https://docs.databricks.com/user-guide/tables.html (see Create Partitioned Table section)
     val lCreateTableScript = s"""
                                  CREATE EXTERNAL TABLE IF NOT EXISTS ${internalGetTable(huemulType_InternalTableType.OldValueTrace)} (${getColumns_CreateTable(true, huemulType_InternalTableType.OldValueTrace) })
-                                  ${if (_StorageType_OldValueTrace == "csv") {s"""
+                                  ${if (getStorageType_OldValueTrace == "csv") {s"""
                                   ROW FORMAT DELIMITED
                                   FIELDS TERMINATED BY '\t'
                                   STORED AS TEXTFILE """}
-                                  else if (_StorageType_OldValueTrace == "json") {
+                                  else if (getStorageType_OldValueTrace == "json") {
                                     s"""
                                      ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
                                     """
                                   }
-                                  else if (_StorageType_OldValueTrace == "parquet") {
+                                  else if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET) {
                                    """PARTITIONED BY (MDM_columnName STRING)
                                      STORED AS PARQUET""" 
                                   }
-                                  else if (_StorageType_OldValueTrace == "orc") {
+                                  else if (getStorageType_OldValueTrace == huemulType_StorageType.ORC) {
                                    """PARTITIONED BY (MDM_columnName STRING)
                                      STORED AS ORC""" 
                                   }
@@ -1994,14 +2281,22 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                                                                    GROUP BY ${SQL_PK}
                                                                                    HAVING COUNT(1) > 1
                                                                                 """)
-        //val numReg_01 = df_detail_01.count()
+                                                                                
+        df_detail_01.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
+        val numReg_01 = df_detail_01.count()
+         //Broadcast
+        var _NumRows_PK: String = ""
+        if (numReg_01 < 50000)
+          _NumRows_PK = "/*+ BROADCAST(dup) */"
+          
         //get rows duplicated
         LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step2)")
-        val df_detail_02 = huemulBigDataGov.DF_ExecuteQuery("___temp_pk_det_02", s""" SELECT /*+ BROADCAST(dup) */ PK.*
+        val df_detail_02 = huemulBigDataGov.DF_ExecuteQuery("___temp_pk_det_02", s""" SELECT ${_NumRows_PK} PK.*
                                                                                    FROM ${this.DataFramehuemul.Alias} PK
                                                                                      INNER JOIN ___temp_pk_det_01 dup
                                                                                         ON ${SQL_PK_on}
                                                                                 """)   
+        df_detail_02.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
         val numReg = df_detail_02.count()                                                                                 
                                                                               
         val DQ_Id_PK = ResultDQ.getDQResult().filter { dqres => dqres.DQ_ErrorCode == 1018 }(0).DQ_Id
@@ -2018,7 +2313,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         //Execute query
         LocalControl.NewStep(s"Step: DQ Result: Get detail error for PK Error (step3, $numReg rows)")
         var DF_EDetail = huemulBigDataGov.DF_ExecuteQuery("temp_DQ_PK", SQL_Detail)
-                             
+        DF_EDetail.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
+        val numCount = DF_EDetail.count()
         if (ResultDQ.DetailErrorsDF == null)
           ResultDQ.DetailErrorsDF = DF_EDetail
         else
@@ -2098,7 +2394,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         //Exist, copy for use
         val dt_start = huemulBigDataGov.getCurrentDateTimeJava()
         //Open actual file
-        val DFTempCopy = huemulBigDataGov.spark.read.format(this._StorageType.toString()).load(FullPathString)
+        val DFTempCopy = huemulBigDataGov.spark.read.format(this.getStorageType.toString()).load(FullPathString)
         val tempPath = huemulBigDataGov.GlobalSettings.GetDebugTempPath(huemulBigDataGov, huemulBigDataGov.ProcessNameCall, TempAlias)
         if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"copy to temp dir: $tempPath ")
         if (this.getNumPartitions == null || this.getNumPartitions <= 0)
@@ -2205,6 +2501,9 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //STEP 2: Execute final table //Add debugmode and getnumpartitions in v1.3
       DataFramehuemul._CreateFinalQuery(AliasNewData , SQLFinalTable, huemulBigDataGov.DebugMode , this.getNumPartitions, this, storageLevelOfDF)
       
+      //from 2.2 --> persist to improve performance
+      DataFramehuemul.DataFrame.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
+      
       //LocalControl.NewStep("Transaction: Get Statistics info")
       this.UpdateStatistics(LocalControl, "Transaction", null)
       
@@ -2251,35 +2550,70 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       val dt_start = huemulBigDataGov.getCurrentDateTimeJava()
       val TempAlias: String = s"__${this.TableName}_old"
       val fs = FileSystem.get(huemulBigDataGov.spark.sparkContext.hadoopConfiguration)
-      if (fs.exists(new org.apache.hadoop.fs.Path(this.getFullNameWithPath()))){
-        //Exist, copy for use
-        
-        //Open actual file
-        val DFTempCopy = huemulBigDataGov.spark.read.format(this._StorageType.toString()).load(this.getFullNameWithPath())
-        
-        //2.0: save previous to backup
-        var tempPath: String = null
-        if (huemulBigDataGov.GlobalSettings.MDM_SaveBackup && this._SaveBackup){
-          tempPath = this.getFullNameWithPath_Backup(Control.Control_Id )
-          _BackupPath = tempPath
-          if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"copy to backup dir: $tempPath ")
-        } else {
-          tempPath = huemulBigDataGov.GlobalSettings.GetDebugTempPath(huemulBigDataGov, huemulBigDataGov.ProcessNameCall, TempAlias)
-          if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"copy to temp dir: $tempPath ")
+      
+      var oldDataFrameExists = false
+      
+      if (this.getStorageType == huemulType_StorageType.HBASE) {
+        val hBaseConnector = new huemul_TableConnector(huemulBigDataGov, LocalControl)
+        if (hBaseConnector.tableExistsHBase(getHBaseNamespace(huemulType_InternalTableType.Normal),getHBaseTableName(huemulType_InternalTableType.Normal))) {
+          oldDataFrameExists = true
+          //println(getHBaseCatalog(huemulType_InternalTableType.Normal))
+          //val DFHBase = hBaseConnector.getDFFromHBase(TempAlias, getHBaseCatalog(huemulType_InternalTableType.Normal))
+          
+          //create external table if doesn't exists
+          CreateTableScript = DF_CreateTableScript()          
+          huemulBigDataGov.HIVE_connection.ExecuteJDBC_NoResulSet(CreateTableScript)
+            
+          LocalControl.NewStep("Ref & Master: Reading HBase data...")     
+          val DFHBase = huemulBigDataGov.DF_ExecuteQuery(TempAlias, s"SELECT * FROM ${this.internalGetTable(huemulType_InternalTableType.Normal)}")
+          val numRows = DFHBase.count()
+          if (huemulBigDataGov.GlobalSettings.MDM_SaveBackup && this._SaveBackup){
+            var tempPath = this.getFullNameWithPath_Backup(Control.Control_Id )
+            _BackupPath = tempPath
+            if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"copy to backup dir: $tempPath ")
+         
+            LocalControl.NewStep("Ref & Master: Backup...")
+            DFHBase.write.mode(SaveMode.Overwrite).format("parquet").save(tempPath)     //2.2 -> this._StorageType.toString() instead of "parquet"
+          }
+          
+          
+          //DFHBase.show()
         }
-        
-        if (this.getNumPartitions == null || this.getNumPartitions <= 0)
-          DFTempCopy.write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(tempPath)     //2.2 -> this._StorageType.toString() instead of "parquet"
-        else
-          DFTempCopy.repartition(this.getNumPartitions).write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(tempPath)   //2.2 -> this._StorageType.toString() instead of "parquet"
-        DFTempCopy.unpersist()
-       
-        //Open temp file
-        if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"open temp old df: $tempPath ")
-        val DFTempOpen = huemulBigDataGov.spark.read.format(this._StorageType.toString()).load(tempPath)  //2.2 --> read.format(this._StorageType.toString()).load(tempPath)    instead of  read.parquet(tempPath)   
-        DFTempOpen.createOrReplaceTempView(TempAlias)        
       } else {
-          huemulBigDataGov.logMessageInfo(s"create empty dataframe because ${this.internalGetTable(huemulType_InternalTableType.Normal)} does not exist")
+        if (fs.exists(new org.apache.hadoop.fs.Path(this.getFullNameWithPath()))){
+          //Exist, copy for use
+          oldDataFrameExists = true
+          
+          //Open actual file
+          val DFTempCopy = huemulBigDataGov.spark.read.format(this.getStorageType.toString()).load(this.getFullNameWithPath())
+          
+          //2.0: save previous to backup
+          var tempPath: String = null
+          if (huemulBigDataGov.GlobalSettings.MDM_SaveBackup && this._SaveBackup){
+            tempPath = this.getFullNameWithPath_Backup(Control.Control_Id )
+            _BackupPath = tempPath
+            if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"copy to backup dir: $tempPath ")
+          } else {
+            tempPath = huemulBigDataGov.GlobalSettings.GetDebugTempPath(huemulBigDataGov, huemulBigDataGov.ProcessNameCall, TempAlias)
+            if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"copy to temp dir: $tempPath ")
+          }
+          
+          if (this.getNumPartitions == null || this.getNumPartitions <= 0)
+            DFTempCopy.write.mode(SaveMode.Overwrite).format(this.getStorageType.toString()).save(tempPath)     //2.2 -> this._StorageType.toString() instead of "parquet"
+          else
+            DFTempCopy.repartition(this.getNumPartitions).write.mode(SaveMode.Overwrite).format(this.getStorageType.toString()).save(tempPath)   //2.2 -> this._StorageType.toString() instead of "parquet"
+          DFTempCopy.unpersist()
+         
+          //Open temp file
+          if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"open temp old df: $tempPath ")
+          val DFTempOpen = huemulBigDataGov.spark.read.format(this.getStorageType.toString()).load(tempPath)  //2.2 --> read.format(this._StorageType.toString()).load(tempPath)    instead of  read.parquet(tempPath)   
+          DFTempOpen.createOrReplaceTempView(TempAlias)        
+        }
+      }
+      
+      if (!oldDataFrameExists) {
+          //huemulBigDataGov.logMessageInfo(s"create empty dataframe because ${this.internalGetTable(huemulType_InternalTableType.Normal)} does not exist")
+          huemulBigDataGov.logMessageInfo(s"create empty dataframe because oldDF does not exist")
           val Schema = getSchema()
           val SchemaForEmpty = StructType(Schema.map { x => StructField(x.name, x.dataType, x.nullable) })
           val EmptyRDD = huemulBigDataGov.spark.sparkContext.emptyRDD[Row]
@@ -2309,6 +2643,9 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                               , SQL_Step1_FullJoin(TempAlias, NextAlias, isUpdate, isDelete)
                                               , Control //parent control 
                                              )
+      
+      //from 2.2 --> add to compatibility with HBase (without this, OldValueTrace doesn't work becacuse it recalculate with new HBase values                                       
+      SQLFullJoin_DF.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
                                              
                                              
       //STEP 2: Create Tabla with Update and Insert result
@@ -2490,7 +2827,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       if (huemulBigDataGov.HasName(x.get_MappedName())) {
         //val ColumnNames = if (UseAliasColumnName) x.get_MappedName() else x.get_MyName()
         val ColumnNames = x.get_MyName()
-        val ColumnInSchema = Schema.filter { y => y.name == ColumnNames }
+        val ColumnInSchema = Schema.filter { y => y.name.toLowerCase() == ColumnNames.toLowerCase() }
         if (ColumnInSchema == null || ColumnInSchema.length == 0)
           raiseError(s"huemul_Table Error: column missing in Schema ${ColumnNames}", 1038)
         if (ColumnInSchema.length != 1)
@@ -2557,6 +2894,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //from 2.1: exclude_warnings, update DataFramehuemul 
       excludeRows(LocalControl)
    
+      //from 2.2 --> raiserror if DF is empty
+      if (this.DataFramehuemul.getNumRows() == 0) {
+        this.raiseError(s"huemul_Table Error: Dataframe is empty, nothing to save", 1062)
+      }
+      
     //REST OF RULES (DIFFERENT FROM WARNING_EXCLUDE)
       //DataQuality by Columns
       LocalControl.NewStep("Start DataQuality ERROR AND WARNING")
@@ -2742,6 +3084,9 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
    
       if (OnlyInsert && !IsSelectiveUpdate) {
         DF_Final = DF_Final.where("___ActionType__ = 'NEW'") 
+      } else if (this.getStorageType == huemulType_StorageType.HBASE){
+        //exclude "EQUAL" to improve write performance on HBase
+        DF_Final = DF_Final.where("___ActionType__ != 'EQUAL'")
       }
       
       DF_Final = DF_Final.drop("___ActionType__").drop("SameHashKey") //from 2.1: always this columns exist on reference and master tables
@@ -2805,14 +3150,33 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           DF_Final = DF_Final.repartition(this.getNumPartitions)
         }
                 
+        var localSaveMode: SaveMode = null
         if (OnlyInsert) {
           LocalControl.NewStep("Save: Append Master & Ref Data")
-          DF_Final.write.mode(SaveMode.Append).format(this._StorageType.toString()).save(getFullNameWithPath())
+          localSaveMode = SaveMode.Append
         }
         else {
           LocalControl.NewStep("Save: Overwrite Master & Ref Data")
-          DF_Final.write.mode(SaveMode.Overwrite).format(this._StorageType.toString()).save(getFullNameWithPath())
+          localSaveMode = SaveMode.Overwrite
         }
+        
+       
+        if (this.getStorageType == huemulType_StorageType.HBASE){
+          if (DF_Final.count() > 0) {
+            val huemulDriver = new huemul_TableConnector(huemulBigDataGov, LocalControl)
+            huemulDriver.saveToHBase(DF_Final
+                                    ,getHBaseNamespace(huemulType_InternalTableType.Normal)
+                                    ,getHBaseTableName(huemulType_InternalTableType.Normal)
+                                    ,this.getNumPartitions //numPartitions
+                                    ,OnlyInsert
+                                    ,if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey" //PKName
+                                    ,getALLDeclaredFields_forHBase(getALLDeclaredFields(false))
+                                    )
+          }
+        }
+        else 
+          DF_Final.write.mode(localSaveMode).format(this.getStorageType.toString()).save(getFullNameWithPath())
+        
         
         //val fs = FileSystem.get(huemulBigDataGov.spark.sparkContext.hadoopConfiguration)       
         //fs.setPermission(new org.apache.hadoop.fs.Path(GetFullNameWithPath()), new FsPermission("770"))
@@ -2839,7 +3203,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           LocalControl.NewStep("Save: OverWrite partition with new data")
           if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${FullPath} ")     
           
-          DF_Final.write.mode(SaveMode.Append).format(this._StorageType.toString()).partitionBy(_PartitionField).save(getFullNameWithPath())
+          DF_Final.write.mode(SaveMode.Append).format(this.getStorageType.toString()).partitionBy(_PartitionField).save(getFullNameWithPath())
                 
           //fs.setPermission(new org.apache.hadoop.fs.Path(GetFullNameWithPath()), new FsPermission("770"))
   
@@ -2877,7 +3241,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           LocalControl.NewStep("Save: Create Table in Hive Metadata")
           CreateTableScript = DF_CreateTableScript() 
          
-          huemulBigDataGov.spark.sql(CreateTableScript)
+          //from 2.2 --> create HBAse table using JDBC Hive connection
+          if (getStorageType == huemulType_StorageType.HBASE)
+            huemulBigDataGov.HIVE_connection.ExecuteJDBC_NoResulSet(CreateTableScript)
+          else 
+            huemulBigDataGov.spark.sql(CreateTableScript)
         }
     
         //Hive read partitioning metadata, see https://docs.databricks.com/user-guide/tables.html
@@ -2915,6 +3283,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     return Result
     
   }
+    
+  
   
   /**
    * Save DQ Result data to disk
@@ -2927,12 +3297,13 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     try {      
       LocalControl.NewStep("Save: OldVT Result: Saving Old Value Trace result")
       if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${getFullNameWithPath_OldValueTrace()} ")
-      if (_StorageType_OldValueTrace.toLowerCase() == "parquet"){
-        DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(_StorageType_OldValueTrace).save(getFullNameWithPath_OldValueTrace())
+      if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET || getStorageType_OldValueTrace == huemulType_StorageType.ORC){
+        DF_Final.write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
+        //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
         //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(_StorageType_OldValueTrace).save(GetFullNameWithPath_OldValueTrace())
       }
       else
-        DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).option("delimiter", "\t").option("emptyValue", "").option("treatEmptyValuesAsNulls", "false").option("nullValue", "null").format(_StorageType_OldValueTrace).save(getFullNameWithPath_OldValueTrace())
+        DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).option("delimiter", "\t").option("emptyValue", "").option("treatEmptyValuesAsNulls", "false").option("nullValue", "null").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
       
     } catch {
       case e: Exception => 
@@ -3004,8 +3375,22 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       
     try {      
       LocalControl.NewStep("Save DQ Result: Saving new DQ result")
-      if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${getFullNameWithPath_DQ()} ")        
-      DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(this._StorageType.toString()).partitionBy("dq_control_id").save(getFullNameWithPath_DQ())
+      //from 2.2 --> add HBase storage (from table definition) --> NOT SUPPORTED
+      if (this.getStorageType_DQResult == huemulType_StorageType.HBASE) {
+        val huemulDriver = new huemul_TableConnector(huemulBigDataGov, LocalControl)
+        huemulDriver.saveToHBase(DF_Final
+                                  ,getHBaseNamespace(huemulType_InternalTableType.DQ)
+                                  ,getHBaseTableName(huemulType_InternalTableType.DQ)
+                                  ,this.getNumPartitions //numPartitions
+                                  ,true
+                                  ,if (_numPKColumns == 1) _HBase_PKColumn else "hs_rowkey" //PKName
+                                  ,getALLDeclaredFields_forHBase(getALLDeclaredFields(false))
+                                  )      
+      } else {
+        if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${getFullNameWithPath_DQ()} ")        
+        //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(this.getStorageType_DQResult.toString()).partitionBy("dq_control_id").save(getFullNameWithPath_DQ())
+        DF_Final.write.mode(SaveMode.Append).format(this.getStorageType_DQResult.toString()).partitionBy("dq_control_id").save(getFullNameWithPath_DQ())
+      }
       
     } catch {
       case e: Exception => 

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableConnector.scala
@@ -1,0 +1,337 @@
+package com.huemulsolutions.bigdata.tables
+
+import com.huemulsolutions.bigdata.control.huemul_Control
+import org.apache.spark.sql._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import com.huemulsolutions.bigdata.common.huemul_BigDataGovernance
+
+
+import org.apache.hadoop.hbase.{HBaseConfiguration, TableName}
+import org.apache.hadoop.hbase.spark.HBaseContext
+import org.apache.hadoop.hbase.spark.HBaseRDDFunctions._
+import org.apache.hadoop.hbase.client.{Connection,ConnectionFactory,HBaseAdmin,HTable,Put,Get}
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.spark.KeyFamilyQualifier
+import org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles
+import org.apache.hadoop.hbase.client.Delete
+import org.apache.hadoop.hbase.client.Admin
+//import org.apache.hadoop.hbase.HTableDescriptors // HTableDescriptor
+import org.apache.hadoop.hbase.HColumnDescriptor
+import org.apache.hive.jdbc.HiveConnection
+//import org.apache.hadoop.hbase.spark.datasources.HBaseTableCatalog
+
+
+class huemul_TableConnector(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_Control) extends Serializable {
+  
+  def tableDeleteHBase(HBase_Namespace: String
+                     , HBase_tableName: String) = {
+
+    //Crea tabla
+    
+    val hbaseConf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(huemulBigDataGov.spark.sparkContext, hbaseConf)
+    
+    
+    val connection = ConnectionFactory.createConnection(hbaseConf)
+    val admin = connection.getAdmin()
+    
+    val tableNameString: String = s"${HBase_Namespace}:${HBase_tableName}"
+    val tableName: org.apache.hadoop.hbase.TableName = org.apache.hadoop.hbase.TableName.valueOf(tableNameString)
+    
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName)
+      admin.deleteTable(tableName)
+    }
+      
+    admin.close()
+    connection.close()
+    
+    
+  }
+  
+  def tableExistsHBase(HBase_Namespace: String
+                     , HBase_tableName: String): Boolean = {
+    var result: Boolean = false
+    //Crea tabla
+    Control.NewStep(s"HBase: Create hBaseConfiguration and HBaseContext")
+    val hbaseConf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(huemulBigDataGov.spark.sparkContext, hbaseConf)
+    
+    Control.NewStep("HBase: Create connection")
+    val connection = ConnectionFactory.createConnection(hbaseConf)
+    val admin = connection.getAdmin()
+    
+    val tableNameString: String = s"${HBase_Namespace}:${HBase_tableName}"
+    val tableName: org.apache.hadoop.hbase.TableName = org.apache.hadoop.hbase.TableName.valueOf(tableNameString)
+    
+    Control.NewStep(s"HBase: Namespaces validation...")
+    result = admin.tableExists(tableName)
+    
+    admin.close()
+    connection.close()
+    
+    return result
+  }
+  
+  /*
+  def getDFFromHBase(Alias: String, catalog: String): DataFrame = {
+    val DF = huemulBigDataGov.spark.read.options(Map(HBaseTableCatalog.tableCatalog->catalog)).format("org.apache.hadoop.hbase.spark").load()
+    DF.createOrReplaceTempView(Alias)
+    return DF
+  }
+  * 
+  */
+  
+  def saveToHBase(DF_to_save: DataFrame
+                , HBase_Namespace: String
+                , HBase_tableName: String
+                , numPartitions: Int
+                , isOnlyInsert: Boolean
+                , DF_ColumnPKName: String
+                ): Boolean = {
+    return saveToHBase(DF_to_save
+                                    ,HBase_Namespace
+                                    ,HBase_tableName
+                                    ,numPartitions
+                                    ,isOnlyInsert
+                                    ,DF_ColumnPKName
+                                    ,null)
+  }
+    
+  
+  def saveToHBase(DF_to_save: DataFrame
+                , HBase_Namespace: String
+                , HBase_tableName: String
+                , numPartitions: Int
+                , isOnlyInsert: Boolean
+                , DF_ColumnPKName: String
+                , huemulDeclaredFieldsForHBase : Array[(java.lang.reflect.Field, String, String, DataType)] //Optional
+                ): Boolean = {
+    var result: Boolean = true
+    
+    var numPartition: String = if (numPartitions > 5) numPartitions.toString() else "5"
+    Control.NewStep(s"HBase: num partitions = ${numPartition} ")
+
+    //get Schema
+    val __schema = DF_to_save.schema
+    
+    //GET index to PK
+    var indexPK = -1
+    var isFound: Boolean = false
+    __schema.foreach { x => 
+      if (!isFound) {
+        indexPK+=1
+        if (x.name.toLowerCase() == DF_ColumnPKName.toLowerCase())
+          isFound = true   
+      }
+    }
+    
+    //create array with family and column info
+    val __valCols1 = __schema.filter { x => x.name.toLowerCase() != DF_ColumnPKName.toLowerCase()  } .map { x => {
+      var fam: String = "default"
+      var nom: String = x.name
+      var dataType: DataType = __schema.fields( __schema.fieldIndex(x.name)).dataType
+      var pos = __schema.fieldIndex(x.name)
+
+      //Only if huemulDeclaredFields has value
+      if (huemulDeclaredFieldsForHBase != null) {
+        val fam_fil = huemulDeclaredFieldsForHBase.filter { y => y._1.getName.toUpperCase() == x.name.toUpperCase() }
+        
+        if (fam_fil.length == 1) {
+          val __reg = fam_fil(0) 
+          fam = __reg._2
+          nom = __reg._3
+          dataType = __reg._4
+        }
+      }
+      
+      (nom, fam, dataType, pos )
+    }}
+
+    //reorder to optimize HBase insert
+    @transient lazy val __valCols2 = __valCols1.sortBy( f => f._2.concat(f._1))
+    //get num cols
+    @transient lazy  val __numCols2: Int = __valCols2.length
+
+    Control.NewStep(s"HBase: Map to HBase format ")
+    
+    //map to HBase format (keyValue, family, colname, value)
+    import huemulBigDataGov.spark.implicits._ 
+    val __pdd_2 = DF_to_save.flatMap(row => {
+      val rowKey = row(indexPK).toString() //Bytes.toBytes(x._1)
+      
+      for (ii <- 0 until __numCols2) yield {
+          val colName = __valCols2(ii)._1.toString()
+          val famName = __valCols2(ii)._2.toString()
+          val colDataType = __valCols2(ii)._3
+          var colValue: Array[Byte] = null
+          val y = __valCols2(ii)._4
+
+          if (row(y) == null)
+            colValue = null
+          else if (colDataType == DataTypes.BooleanType)
+            colValue = Bytes.toBytes(row.getBoolean(y)) 
+          else if (colDataType == DataTypes.ShortType)
+            colValue = Bytes.toBytes(row.getShort(y))
+          else if (colDataType == DataTypes.LongType)
+            colValue = Bytes.toBytes(row.getLong(y))
+          //else if (colDataType == DataTypes.BinaryType)
+          //  colValue = Bytes.toBytes(row.getBinary(y))
+          else if (colDataType == DataTypes.StringType)
+            colValue = Bytes.toBytes(row(y).toString())
+          //else if (colDataType == DataTypes.NullType)
+          //  colValue = Bytes.toBytes(row.getAs[NullType](columnName)
+          else if (colDataType == DecimalType || colDataType.typeName.toLowerCase().contains("decimal"))
+            colValue = Bytes.toBytes(row(y).toString())
+            //colValue = Bytes.toBytes(row.getDecimal(y))
+          else if (colDataType == DataTypes.IntegerType)
+            colValue = Bytes.toBytes(row.getInt(y))
+          else if (colDataType == DataTypes.FloatType)
+            colValue = Bytes.toBytes(row.getFloat(y))
+          else if (colDataType == DataTypes.DoubleType)
+            colValue = Bytes.toBytes(row.getDouble(y))
+          else if (colDataType == DataTypes.DateType)
+            colValue = Bytes.toBytes(row(y).toString())
+          else if (colDataType == DataTypes.TimestampType)
+            colValue = Bytes.toBytes(row(y).toString())
+          else
+            colValue = Bytes.toBytes(row(y).toString())
+                
+          (rowKey, (famName, colName, colValue))
+        }
+      }
+    ).rdd
+    
+    __pdd_2.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_SER)
+    val numRowsTot = __pdd_2.count()
+        
+     //Table Assign
+    Control.NewStep(s"HBase: Set staging Folder and Family:Table Name")
+    
+    val tableNameString: String = s"${HBase_Namespace}:${HBase_tableName}"
+    val tableName: org.apache.hadoop.hbase.TableName = org.apache.hadoop.hbase.TableName.valueOf(tableNameString)
+    
+    //Starting HBase
+    Control.NewStep(s"HBase: Create hBaseConfiguration and HBaseContext")
+    val hbaseConf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(huemulBigDataGov.spark.sparkContext, hbaseConf)
+    
+    //create table
+    Control.NewStep("HBase: Create connection")
+    val connection = ConnectionFactory.createConnection(hbaseConf)
+    val admin = connection.getAdmin()
+    
+    Control.NewStep(s"HBase: Namespaces validation...")
+    val _listNamespace = admin.listNamespaceDescriptors()
+    
+    //Create namespace if it doesn't exist
+    //_listNamespace.foreach { x => println(x.getName) }
+    if (_listNamespace.filter { x => x.getName == HBase_Namespace }.length == 0) {
+      admin.createNamespace(org.apache.hadoop.hbase.NamespaceDescriptor.create(HBase_Namespace).build())
+    }
+    
+    Control.NewStep("HBase: TableExists validation...")
+    if (!admin.tableExists(tableName)) {
+      /* desde hbase 2.0
+      val __newTable = TableDescriptorBuilder.newBuilder(tableName)
+                  .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder("default".getBytes).build())
+                  .build()
+                  * 
+                  */
+     
+      Control.NewStep(s"HBase: Table doesn't exists, creating table... ")
+      val __newTable = new org.apache.hadoop.hbase.HTableDescriptor(tableName)
+      
+      //Add families
+      val a = __valCols2.map(x=>x._2).distinct.foreach { x => 
+        __newTable.addFamily(new HColumnDescriptor(x))  
+      }
+      
+      admin.createTable(__newTable)
+    } else {
+      Control.NewStep(s"HBase: Table exists, get families ")
+      val __oldTable = admin.getTableDescriptor(tableName)
+      val _getFamilies = __oldTable.getFamilies.toArray()
+      var _newFamilies = __valCols2.map(x=>x._2).distinct
+      
+      /*
+       * CHECK FAMILIES
+       */
+      //get current families
+      _getFamilies.foreach { x =>
+            val _reg = x.asInstanceOf[org.apache.hadoop.hbase.HColumnDescriptor].getNameAsString
+            //println(_reg)
+              _newFamilies = _newFamilies.filter { y => y != _reg }
+            }
+      
+      //Add new families
+      if (_newFamilies.length > 0) {
+        Control.NewStep(s"HBase: creating new families ")
+        val a = _newFamilies.foreach { x => 
+          //println(s"nuevas: ${x}")
+        __oldTable.addFamily(new HColumnDescriptor(x))  
+        }
+        
+        admin.modifyTable(tableName, __oldTable)
+        
+        //sys.error("fin obligatorio")
+      }
+                    
+    }
+    
+    //elimina los registros que tengan algún valor en null
+    //si es OnlyInsert no existen los registros anteriormente, por tanto no hay registros nulos que eliminar.
+    if (!isOnlyInsert) {
+      Control.NewStep(s"HBase: set null when previous values were not null")
+      val __tdd_null = __pdd_2.filter(x=> x._2._3 == null).map(x=>x._1).distinct().map(x=> Bytes.toBytes(x))
+      Control.NewStep("HBase: Delete nulls")
+      hbaseContext.bulkDelete[Array[Byte]](__tdd_null
+              ,tableName
+              ,putRecord => new Delete( putRecord)
+      		     
+              ,4)
+    }
+        
+    Control.NewStep(s"HBase: exclude null values ")
+    val __tdd_notnull = __pdd_2.filter(x=> x._2._3 != null)
+    
+    val stagingFolder = s"/tmp/user/${Control.getStepId}"
+    huemulBigDataGov.logMessageDebug(s"staging folder: ${stagingFolder}")
+  
+    Control.NewStep(s"HBase: insert and update values ")
+    if (__tdd_notnull.count() > 0) {
+      __tdd_notnull.hbaseBulkLoad(hbaseContext
+                            , tableName
+                            , t =>  {
+                              val rowKey = Bytes.toBytes(t._1)
+                              val family: Array[Byte] = Bytes.toBytes(t._2._1)
+                              val qualifier = Bytes.toBytes(t._2._2)
+                              val value = t._2._3
+                              
+                              val keyFamilyQualifier = new KeyFamilyQualifier(rowKey,family, qualifier)
+                              Seq((keyFamilyQualifier, value)).iterator
+                              
+                            }
+                            , stagingFolder)
+      
+      Control.NewStep(s"HBase: execute HBase job ")
+      val load = new LoadIncrementalHFiles(hbaseConf)
+      load.run(Array(stagingFolder, tableNameString))
+    }
+      
+    admin.close()
+    connection.close()
+    
+    /*
+    DF_to_save.write.mode(localSaveMode).options(Map(HBaseTableCatalog.tableCatalog -> getHBaseCatalog()
+                                                   , HBaseTableCatalog.newTable -> numPartition)
+                                                ).format(huemulBigDataGov.GlobalSettings.getHBase_formatTable()).save()
+                                                * 
+                                                */
+  
+    return result
+  }
+  
+  
+}

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_TableDQ.scala
@@ -3,12 +3,12 @@ package com.huemulsolutions.bigdata.tables
 import org.apache.spark.sql.types._
 
 class huemul_TableDQ extends Serializable  {
-  val dq_control_id = new huemul_Columns (StringType, false, "DQ Id partition (control_id)", false)
-  val dq_dq_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false)
-  val dq_error_columnname = new huemul_Columns (StringType, false, "DQ Column Name ", false)
-  val dq_error_notification = new huemul_Columns (StringType, false, "DQ Notification", false)
-  val dq_error_code = new huemul_Columns (StringType, false, "DQ Error Code", false)
-  val dq_error_descripcion = new huemul_Columns (StringType, false, "DQ User error descripcion", false)
+  val dq_control_id = new huemul_Columns (StringType, false, "DQ Id partition (control_id)", false).setHBaseCatalogMapping("dqinfo")
+  val dq_dq_id = new huemul_Columns (StringType, false, "Id DQ (dq_id in control_dq table)", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_columnname = new huemul_Columns (StringType, false, "DQ Column Name ", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_notification = new huemul_Columns (StringType, false, "DQ Notification", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_code = new huemul_Columns (StringType, false, "DQ Error Code", false).setHBaseCatalogMapping("dqinfo")
+  val dq_error_descripcion = new huemul_Columns (StringType, false, "DQ User error descripcion", false).setHBaseCatalogMapping("dqinfo")
 
   
 }


### PR DESCRIPTION
Se implementan las siguientes mejoras:

* **#79. Eliminar Backup de tablas maestras y de referencia:** Agrega método control_getBackupToDelete(numBackupToMaintain: Int): Boolean. Recibe el parámetro "numBackupToMaintain" que indica la cantidad de backup que se mantendrán en HDFS (los "N" más nuevos). El resto los elimina.
* **#65. Integración con HBase:** Se agrega soporte para almacenar tablas de referencia y maestras en HBase.
* **#66. Integración con ORC:** Se agrega soporte para almacenar tablas en formato ORC.

Se implementan las siguientes correcciones (bug):

* **#75. Mejorar método control_getDQResultForWarningExclude:** Cuando modelo de control está apagado, se rescata esta información desde un arreglo interno y no desde el modelo de control.