### PR TITLE
Develop 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,14 @@ Finalmente, también automatiza la generación de código a partir de las defini
          <version>1.1.2</version>
      </dependency>
 	
+	<!-- https://mvnrepository.com/artifact/com.hortonworks.hive/hive-warehouse-connector -->
+	<dependency>
+	    <groupId>com.hortonworks.hive</groupId>
+	    <artifactId>hive-warehouse-connector_2.11</artifactId>
+	    <version>1.0.0.3.1.0.0-78</version>
+	</dependency>
+		
+		
 		
 		
 	<!-- https://mvnrepository.com/artifact/org.apache.tika/tika-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -2,18 +2,16 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
   <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>2.4</version>
+  <version>2.5</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data lineage for BigData Projects.
-  Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.
+Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.
 
 Permite implementar tablas con control de Primary Key y Foreing Key al insertar y actualizar datos utilizando la librería, Validación de nulos, largos de textos, máximos/mínimos de números y fechas, valores únicos y valores por default. También permite clasificar los campos en aplicabilidad de derechos ARCO para facilitar la implementación de leyes de protección de datos tipo GDPR, identificar los niveles de seguridad y si se está aplicando algún tipo  de encriptación. Adicionalmente permite agregar reglas de validación más complejas sobre la misma tabla.
 
 Facilita la configuración y lectura de las interfaces de entrada, permitiendo ajustar los parámetros de lectura en esquemas altamente cambientes, crea trazabilidad de las interfaces con las tablas en forma automática, y almacena los diccionarios de datos en un repositorio central.
 
-Finalmente, también automatiza la generación de código a partir de las definiciones de las interfaces de entrada, y la creación del código inicial de lógica de negocio.
-  
-  </description>
+Finalmente, también automatiza la generación de código a partir de las definiciones de las interfaces de entrada, y la creación del código inicial de lógica de negocio.</description>
   <url>http://www.HuemulSolutions.com</url>
   <inceptionYear>2018</inceptionYear>
   <licenses>

--- a/src/main/resources/Instalacion/huemul_bdg_2.5_minor.sql
+++ b/src/main/resources/Instalacion/huemul_bdg_2.5_minor.sql
@@ -1,0 +1,474 @@
+
+CREATE TABLE control_config (   config_id		int
+				 				,version_mayor	int
+				                ,version_minor	int
+				                ,version_patch	int
+								,config_dtlog	varchar(50)
+								,primary key (config_id));
+
+create table  control_executors (
+                                              application_id         varchar(100)
+                                             ,idsparkport            varchar(50)
+                                             ,idportmonitoring       varchar(500)
+                                             ,executor_dtstart       varchar(30)
+                                             ,executor_name          varchar(100)
+                                             ,primary key (application_id)
+                                            );
+
+create table  control_singleton (
+                                              singleton_id         varchar(100)
+                                             ,application_id       varchar(100)
+                                             ,singleton_name       varchar(100)
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,primary key (singleton_id)
+                                            );
+        
+create table  control_area (
+                                              area_id              varchar(50)
+											 ,area_idpadre		   varchar(50)
+                                             ,area_name            varchar(100)
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,mdm_processname      varchar(200)
+                                             ,primary key (area_id)
+                                            );
+                             
+create table  control_process ( 
+                                              process_id           varchar(200)
+                                             ,area_id              varchar(50)
+                                             ,process_name         varchar(200)
+                                             ,process_filename     varchar(200)
+                                             ,process_description  varchar(1000)
+                                             ,process_owner        varchar(200)
+											 ,process_frequency    varchar(50)
+                                             ,mdm_manualchange     int
+                                             ,mdm_fhcreate         varchar(30)
+                                             ,mdm_processname      varchar(200)
+                                             ,primary key (process_id)
+                                            );
+                             
+create table  control_processexec ( 
+                                              processexec_id          varchar(50)
+                                             ,processexec_idparent    varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,malla_id                varchar(50)
+                                             ,application_id          varchar(100)
+                                             ,processexec_isstart     int
+                                             ,processexec_iscancelled int
+                                             ,processexec_isenderror  int
+                                             ,processexec_isendok     int
+                                             ,processexec_dtstart     varchar(30)
+                                             ,processexec_dtend       varchar(30)
+                                             ,processexec_durhour     int
+                                             ,processexec_durmin      int
+                                             ,processexec_dursec      int
+                                             ,processexec_whosrun     varchar(200)
+                                             ,processexec_debugmode   int
+                                             ,processexec_environment varchar(200)
+											 ,processexec_param_year	int 
+											 ,processexec_param_month	int 
+											 ,processexec_param_day		int 
+											 ,processexec_param_hour	int 
+											 ,processexec_param_min		int 
+											 ,processexec_param_sec		int 
+											 ,processexec_param_others	varchar(1000) 
+											 ,processexec_huemulversion varchar(50)
+											 ,processexec_controlversion varchar(50)
+                                             ,error_id                varchar(50)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexec_id) 
+                                            );
+                             
+create table  control_processexecparams ( 
+                                              processexec_id          varchar(50)
+                                             ,processexecparams_name  varchar(500)
+                                             ,processexecparams_value varchar(4000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexec_id, processexecparams_name) 
+                                            );
+                   
+create table  control_processexecstep ( 
+                                              processexecstep_id      varchar(50)
+                                             ,processexec_id          varchar(50)
+                                             ,processexecstep_name        varchar(200)
+                                             ,processexecstep_status      varchar(20)  
+                                             ,processexecstep_dtstart     varchar(30)
+                                             ,processexecstep_dtend       varchar(30)
+                                             ,processexecstep_durhour     int
+                                             ,processexecstep_durmin      int
+                                             ,processexecstep_dursec      int
+                                             ,error_id                varchar(50)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (processexecstep_id) 
+                                            );
+                                            
+                                            
+create table control_query 		(query_id			     varchar(50)
+								,processexecstep_id      varchar(50)
+                                ,processexec_id          varchar(50)      
+                                ,rawfiles_id             varchar(50)
+                                ,rawfilesdet_id		     varchar(50)
+                                ,table_id                varchar(50)
+                                ,query_alias			 varchar(200)
+                                ,query_sql_from		     varchar(4000)
+                                ,query_sql_where		 varchar(4000)
+                                ,query_numerrors	     int
+                                ,query_autoinc			 int
+                                ,query_israw			 int
+                                ,query_isfinaltable	     int
+                                ,query_isquery			 int
+                                ,query_isreferenced		 int
+                                ,query_numrows_real		 int
+                                ,query_numrows_expected  int
+                                ,query_duration_hour	 int
+                                ,query_duration_min		 int
+                                ,query_duration_sec		 int			 
+                                ,error_id                varchar(50)
+                                ,mdm_fhcreate            varchar(30)
+                                ,mdm_processname         varchar(200)    
+                                ,primary key (query_id)
+                                );
+                                
+create table control_querycolumn 	  (querycol_id					varchar(50)
+									  ,query_id						varchar(50)
+									  ,rawfilesdet_id               varchar(50)
+									  ,column_id                  	varchar(50)
+									  ,querycol_pos					int
+									  ,querycol_name				varchar(200)
+									  ,querycol_sql					varchar(4000)
+									  ,querycol_posstart			int
+									  ,querycol_posend				int
+									  ,querycol_line				int
+									  ,mdm_fhcreate            varchar(30)
+                                	  ,mdm_processname         varchar(200)    
+									  ,primary key (querycol_id)
+                                );
+                                
+create index idx_control_querycolumn_i01 on control_querycolumn (query_id, querycol_name);
+                                
+create table control_querycolumnori		(querycolori_id					varchar(50)       
+										,querycol_id					varchar(50)
+										,table_idori                	varchar(50)
+										,column_idori					varchar(50)
+										,rawfilesdet_idori             	varchar(50)
+										,rawfilesdetfields_idori		varchar(50)
+										,query_idori					varchar(50)
+										,querycol_idori					varchar(50)
+										,querycolori_dbname				varchar(200)
+										,querycolori_tabname			varchar(200)
+										,querycolori_tabalias		 	varchar(200)
+										,querycolori_colname			varchar(200)	
+										,querycolori_isselect			int
+										,querycolori_iswhere			int
+										,querycolori_ishaving			int
+										,querycolori_isorder			int
+										,mdm_fhcreate            varchar(30)
+                                		,mdm_processname         varchar(200)    
+										,primary key (querycolori_id)
+                                );				                 
+									                                                                     
+                    
+create table  control_rawfiles ( 
+                                              rawfiles_id             varchar(50)
+                                             ,area_id                 varchar(50)
+                                             ,rawfiles_logicalname    varchar(500)
+                                             ,rawfiles_groupname      varchar(500)
+                                             ,rawfiles_description    varchar(1000)
+                                             ,rawfiles_owner          varchar(200)
+                                             ,rawfiles_frequency      varchar(200)
+                                             ,mdm_manualchange        int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfiles_id) 
+                                            );
+
+create index idx_control_rawfiles_i01 on control_rawfiles (rawfiles_logicalname, rawfiles_groupname);
+create unique index idx_control_rawfiles_i02 on control_rawfiles (rawfiles_logicalname);
+                                    
+create table  control_rawfilesdet ( 
+                                              rawfilesdet_id                            varchar(50)
+                                             ,rawfiles_id                               varchar(50)
+                                             ,rawfilesdet_startdate                     varchar(30)
+                                             ,rawfilesdet_enddate                       varchar(30)
+                                             ,rawfilesdet_filename                      varchar(1000)
+                                             ,rawfilesdet_localpath                     varchar(1000)
+                                             ,rawfilesdet_globalpath                    varchar(1000)
+                                             ,rawfilesdet_data_colseptype         varchar(50)
+                                             ,rawfilesdet_data_colsep             varchar(50)
+                                             ,rawfilesdet_data_headcolstring      varchar(4000)
+                                             ,rawfilesdet_log_colseptype          varchar(50)
+                                             ,rawfilesdet_log_colsep              varchar(50)
+                                             ,rawfilesdet_log_headcolstring       varchar(4000)
+                                             ,rawfilesdet_log_numrowsfield         varchar(200)
+                                             ,rawfilesdet_contactname                   varchar(200)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesdet_id) 
+                                            );
+
+create index idx_control_rawfilesdet_i01 on control_rawfilesdet (rawfiles_id, rawfilesdet_startdate);
+                                                       
+create table  control_rawfilesdetfields ( 
+                                              rawfilesdet_id                  varchar(50)
+											 ,rawfilesdetfields_logicalname          varchar(200)
+                                             ,rawfilesdetfields_itname          varchar(200)
+                                             ,rawfilesdetfields_description          varchar(1000)
+                                             ,rawfilesdetfields_datatype            varchar(50)
+                                             ,rawfilesdetfields_position      int
+                                             ,rawfilesdetfields_posini        int
+                                             ,rawfilesdetfields_posfin        int
+                                             ,rawfilesdetfields_applytrim     int
+                                             ,rawfilesdetfields_convertnull   int
+											 ,mdm_active			  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesdet_id, rawfilesdetfields_logicalname) 
+                                            );
+											
+                  
+create table  control_rawfilesuse ( 
+                                              rawfilesuse_id          varchar(50)
+                                             ,rawfiles_id             varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,rawfilesuse_year        int
+                                             ,rawfilesuse_month       int
+                                             ,rawfilesuse_day         int
+                                             ,rawfilesuse_hour        int
+                                             ,rawfilesuse_minute       int
+                                             ,rawfilesuse_second      int
+                                             ,rawfilesuse_params      varchar(1000)
+                                             ,rawfiles_fullname       varchar(1000)
+                                             ,rawfiles_fullpath       varchar(1000)
+                                             ,rawfiles_numrows        varchar(50)
+                                             ,rawfiles_headerline     varchar(4000)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (rawfilesuse_id) 
+                                            );
+                   
+create table  control_tables ( 
+                                              table_id                varchar(50)
+                                             ,area_id                 varchar(50)
+                                             ,table_bbddname          varchar(200)
+                                             ,table_name              varchar(200)
+                                             ,table_description       varchar(1000)
+                                             ,table_businessowner     varchar(200)
+                                             ,table_itowner           varchar(200)
+                                             ,table_partitionfield    varchar(200)
+                                             ,table_tabletype         varchar(50)  
+											 ,table_compressiontype   varchar(50)  
+                                             ,table_storagetype       varchar(50)
+                                             ,table_localpath         varchar(1000)
+                                             ,table_globalpath        varchar(1000)
+                                             ,table_fullname_dq		  varchar(1200)
+                                             ,table_dq_isused		  int
+                                             ,table_fullname_ovt	  varchar(1200)
+                                             ,table_ovt_isused		  int                                             
+                                             ,table_sqlcreate         varchar(4000)
+											 ,table_frequency		  varchar(200)
+											 ,table_autoincupdate     int
+											 ,table_backup		 	  int
+                                             ,mdm_manualchange        int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)                                             
+                                             ,primary key (table_id) 
+                                            );
+
+create unique index idx_control_tables_i01 on control_tables (table_bbddname, table_name );
+                   
+create table  control_tablesrel (                   
+                                              tablerel_id               varchar(50)
+                                             ,table_idpk                varchar(50)
+                                             ,table_idfk                varchar(50)
+                                             ,tablefk_namerelationship  varchar(100)
+                                             ,tablerel_validnull        int
+                                             ,mdm_manualchange          int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)                                             
+                                             ,primary key (tablerel_id) 
+                                            );
+
+create index idx_control_tablesrel_i01 on control_tablesrel (table_idpk, table_idfk, tablefk_namerelationship); 											
+                    
+create table  control_tablesrelcol ( 
+                                              tablerel_id                varchar(50)
+                                             ,column_idfk                varchar(50)
+                                             ,column_idpk                varchar(50)
+                                             ,mdm_manualchange           int
+                                             ,mdm_fhcreate               varchar(30)
+                                             ,mdm_processname            varchar(200)
+                                             ,primary key (tablerel_id, column_idfk) 
+                                            );
+                                                                       
+                    
+create table  control_columns ( 
+                                              column_id                  varchar(50)
+                                             ,table_id                   varchar(50)
+                                             ,column_position            int
+                                             ,column_name                varchar(200)
+                                             ,column_description         varchar(1000)
+                                             ,column_formula             varchar(1000)
+                                             ,column_datatype            varchar(50)
+                                             ,column_datatypedeploy      varchar(50)
+                                             ,column_sensibledata        int
+                                             ,column_enabledtlog         int
+                                             ,column_enableoldvalue      int
+                                             ,column_enableprocesslog    int
+                                             ,column_enableoldvaluetrace int
+                                             ,column_defaultvalue        varchar(1000)
+                                             ,column_securitylevel       varchar(200)
+                                             ,column_encrypted           varchar(200)
+                                             ,column_arco                varchar(200)
+                                             ,column_nullable            int
+                                             ,column_ispk                int
+                                             ,column_isunique            int
+                                             ,column_dq_minlen           int
+                                             ,column_dq_maxlen           int 
+                                             ,column_dq_mindecimalvalue  decimal(30,10) 
+                                             ,column_dq_maxdecimalvalue  decimal(30,10) 
+                                             ,column_dq_mindatetimevalue varchar(50) 
+                                             ,column_dq_maxdatetimevalue varchar(50)
+											 ,column_dq_regexp           varchar(1000)
+											 ,column_businessglossary	 varchar(100)
+                                             ,column_responsible         varchar(100)
+                                             ,mdm_active                 int
+                                             ,mdm_manualchange           int
+                                             ,mdm_fhcreate               varchar(30)
+                                             ,mdm_processname            varchar(200)
+                                             ,primary key (column_id) 
+                                            );
+
+create index idx_control_columns_i01 on control_columns (table_id, column_name);
+                                                                       
+                   
+create table  control_tablesuse (			  tablesuse_id            varchar(50)  
+                                             ,table_id                varchar(50)
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,processexecstep_id      varchar(50)
+                                             ,tableuse_year        int
+                                             ,tableuse_month       int
+                                             ,tableuse_day         int
+                                             ,tableuse_hour        int
+                                             ,tableuse_minute       int
+                                             ,tableuse_second      int
+                                             ,tableuse_params      varchar(1000)
+                                             ,tableuse_read           int
+                                             ,tableuse_write          int
+                                             ,tableuse_numrowsnew     int
+                                             ,tableuse_numrowsupdate  int
+											 ,tableuse_numrowsupdatable  int
+											 ,tableuse_numrowsnochange  int
+                                             ,tableuse_numrowsmarkdelete  int
+                                             ,tableuse_numrowstotal   int
+                                             ,tableuse_numrowsexcluded			  int
+											 ,tableuse_partitionvalue varchar(200)
+											 ,tableuse_pathbackup	  varchar(1000)
+											 ,tableuse_backupstatus			  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (tablesuse_id) 
+                                            );
+                                            
+                                            
+ CREATE INDEX IDX_control_tablesuse_I01 ON control_tablesuse (tableuse_backupstatus);
+                                             
+                    
+create table  control_dq (
+                                              dq_id                   varchar(50) 
+                                             ,table_id                varchar(50) 
+                                             ,process_id              varchar(200)
+                                             ,processexec_id          varchar(50)
+                                             ,column_id               varchar(50)
+                                             ,column_name             varchar(200)
+                                             ,dq_aliasdf              varchar(200)
+                                             ,dq_name                 varchar(200)
+                                             ,dq_description          varchar(1000)
+                                             ,dq_querylevel           varchar(50)
+                                             ,dq_notification         varchar(50)
+                                             ,dq_sqlformula           varchar(4000)
+                                             ,dq_dq_toleranceerror_rows     int
+                                             ,dq_dq_toleranceerror_percent     decimal(30,10)
+                                             ,dq_resultdq             varchar(4000)
+                                             ,dq_errorcode            int
+                                             ,dq_externalcode         varchar(200)
+                                             ,dq_numrowsok            int
+                                             ,dq_numrowserror         int
+                                             ,dq_numrowstotal         int
+                                             ,dq_iserror              int
+                                             ,dq_iswarning			  int
+                                             ,dq_duration_hour		  int
+                                             ,dq_duration_minute	  int
+                                             ,dq_duration_second	  int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (dq_id) 
+                                            );
+                    
+                   
+create table  control_error ( 
+                                              error_id          varchar(50)
+                                             ,error_message                varchar(4000)
+                                             ,error_code           int
+                                             ,error_trace                varchar(4000)
+                                             ,error_classname                varchar(100)
+                                             ,error_filename                varchar(500)
+                                             ,error_linenumber                varchar(100)
+                                             ,error_methodname                varchar(100)
+                                             ,error_detail                varchar(500)
+                                             ,mdm_fhcrea            varchar(30)
+                                             ,mdm_processname         varchar(1000)
+                                             ,primary key (error_id)
+                                            );
+                                                                       
+                  
+create table  control_date ( 
+                                      date_id		varchar(10)
+                                      ,date_year	int
+                                      ,date_month	int
+                                      ,date_day	int
+                                      ,date_dayofweek	int
+                                      ,date_dayname	varchar(20)
+                                      ,date_monthname	varchar(20)
+                                      ,date_quarter	int
+                                      ,date_week	int
+                                      ,date_isweekend	int
+                                      ,date_isworkday	int
+                                      ,date_isbankworkday	int
+                                      ,date_numworkday		int
+                                      ,date_numworkdayrev	int
+                                      ,mdm_fhcreate            varchar(30)
+                                      ,mdm_processname         varchar(200) 
+                                      ,primary key (date_id) 
+                                      );
+                                                                       
+                 
+create table  control_testplan ( 
+                                              testplan_id             varchar(200)
+                                             ,testplangroup_id        varchar(200)
+                                             ,processexec_id          varchar(200)
+                                             ,process_id              varchar(200)
+                                             ,testplan_name           varchar(200)
+                                             ,testplan_description    varchar(1000)
+                                             ,testplan_resultexpected varchar(1000)  
+                                             ,testplan_resultreal     varchar(1000)
+                                             ,testplan_isok           int
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (testplan_id) 
+                                            );
+                                            
+create index idx_control_testplan_i01 on control_testplan (testplangroup_id, testplan_name);
+                             
+
+create table  control_testplanfeature ( 
+                                              feature_id              varchar(200)
+                                             ,testplan_id             varchar(200)
+                                             ,mdm_fhcreate            varchar(30)
+                                             ,mdm_processname         varchar(200)
+                                             ,primary key (feature_id, testplan_id) 
+                                            );
+                             

--- a/src/main/resources/Instalacion/huemul_cluster_setting_2.5.sh
+++ b/src/main/resources/Instalacion/huemul_cluster_setting_2.5.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+clear
+echo "Creating HDFS Paths: START"
+hdfs dfs -mkdir /user
+hdfs dfs -mkdir /user/data
+hdfs dfs -mkdir /user/data/production
+hdfs dfs -mkdir /user/data/production/temp
+hdfs dfs -mkdir /user/data/production/raw
+hdfs dfs -mkdir /user/data/production/master
+hdfs dfs -mkdir /user/data/production/dim
+hdfs dfs -mkdir /user/data/production/analytics
+hdfs dfs -mkdir /user/data/production/reporting
+hdfs dfs -mkdir /user/data/production/sandbox
+hdfs dfs -mkdir /user/data/production/dqerror
+hdfs dfs -mkdir /user/data/production/mdm_oldvalue
+hdfs dfs -mkdir /user/data/production/backup
+hdfs dfs -mkdir /user/data/experimental
+hdfs dfs -mkdir /user/data/experimental/temp
+hdfs dfs -mkdir /user/data/experimental/raw
+hdfs dfs -mkdir /user/data/experimental/master
+hdfs dfs -mkdir /user/data/experimental/dim
+hdfs dfs -mkdir /user/data/experimental/analytics
+hdfs dfs -mkdir /user/data/experimental/reporting
+hdfs dfs -mkdir /user/data/experimental/sandbox
+hdfs dfs -mkdir /user/data/experimental/dqerror
+hdfs dfs -mkdir /user/data/experimental/mdm_oldvalue
+hdfs dfs -mkdir /user/data/experimental/backup
+echo "Creating HDFS Paths: FINISH"
+echo "STARTING HIVE SETUP"
+hive -e "CREATE DATABASE production_master"
+hive -e "CREATE DATABASE experimental_master"
+hive -e "CREATE DATABASE production_dim"
+hive -e "CREATE DATABASE experimental_dim"
+hive -e "CREATE DATABASE production_analytics"
+hive -e "CREATE DATABASE experimental_analytics"
+hive -e "CREATE DATABASE production_reporting"
+hive -e "CREATE DATABASE experimental_reporting"
+hive -e "CREATE DATABASE production_sandbox"
+hive -e "CREATE DATABASE experimental_sandbox"
+hive -e "CREATE DATABASE production_DQError"
+hive -e "CREATE DATABASE experimental_DQError"
+hive -e "CREATE DATABASE production_mdm_oldvalue"
+hive -e "CREATE DATABASE experimental_mdm_oldvalue"
+echo "STARTING HIVE SETUP"

--- a/src/main/resources/Instalacion/upgrade from 2.4 to 2.5/huemul_bdg_upgrade_2.4_to_2.5.sql
+++ b/src/main/resources/Instalacion/upgrade from 2.4 to 2.5/huemul_bdg_upgrade_2.4_to_2.5.sql
@@ -1,7 +1,7 @@
 
  ALTER TABLE control_columns add column_datatypedeploy			  varchar(50);
  
- UPDATE control_columns SET column_datatypedeploy = column_datatype WHERE column_datatypedeploy IS NULL
+ UPDATE control_columns SET column_datatypedeploy = column_datatype WHERE column_datatypedeploy IS NULL;
  
  
  UPDATE control_config

--- a/src/main/resources/Instalacion/upgrade from 2.4 to 2.5/huemul_bdg_upgrade_2.4_to_2.5.sql
+++ b/src/main/resources/Instalacion/upgrade from 2.4 to 2.5/huemul_bdg_upgrade_2.4_to_2.5.sql
@@ -1,0 +1,14 @@
+
+ ALTER TABLE control_columns add column_datatypedeploy			  varchar(50);
+ 
+ UPDATE control_columns SET column_datatypedeploy = column_datatype WHERE column_datatypedeploy IS NULL
+ 
+ 
+ UPDATE control_config
+ SET version_mayor	= 2
+    ,version_minor	= 5
+    ,version_patch  = 0
+where config_id = 1;
+
+
+ 

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -504,8 +504,12 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
         """)
   }
                 
-  val hive_HWC = new huemul_ExternalHWC(this)
+  private var hive_HWC: huemul_ExternalHWC = null
+  def getHive_HWC: huemul_ExternalHWC = {return hive_HWC}
   
+  if (GlobalSettings.externalBBDD_conf.Using_HWC.getActive() == true || GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE() == true) {
+    hive_HWC = new huemul_ExternalHWC(this)
+  }
   
   /*********************
    * START METHOD
@@ -540,7 +544,8 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     
     //FROM 2.5 --> ADD HORTONWORKS WAREHOSUE CONNECTOR
     if (GlobalSettings.externalBBDD_conf.Using_HWC.getActive() == true || GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE() == true) {
-      hive_HWC.close
+      if (getHive_HWC != null)
+        getHive_HWC.close
     }
         
   }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -52,7 +52,7 @@ import org.apache.log4j.Level
  *  @param LocalSparkSession(opcional) permite enviar una sesión de Spark ya iniciada.
  */
 class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null) extends Serializable  {
-  val currentVersion: String = "2.4"
+  val currentVersion: String = "2.5"
   val GlobalSettings = globalSettings
   val warehouseLocation = new File("spark-warehouse").getAbsolutePath
   //@transient lazy val log_info = org.apache.log4j.LogManager.getLogger(s"$appName [with huemul]")
@@ -845,6 +845,10 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
     _huemul_showDemoLines = value
   }
   
+  //replicated in huemul_columns
+  def getCaseType(tableStorage: com.huemulsolutions.bigdata.tables.huemulType_StorageType.huemulType_StorageType, value: String): String = {
+    return if (tableStorage == com.huemulsolutions.bigdata.tables.huemulType_StorageType.AVRO) value.toLowerCase() else value
+  }
  
   /**
    * Get execution Id from spark monitoring url

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -504,7 +504,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
         """)
   }
                 
-  
+  val hive_HWC = new huemul_ExternalHWC(this)
   
   
   /*********************
@@ -537,6 +537,12 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
           connHIVE.connection.close()
       }
     }
+    
+    //FROM 2.5 --> ADD HORTONWORKS WAREHOSUE CONNECTOR
+    if (GlobalSettings.externalBBDD_conf.Using_HWC.getActive() == true || GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE() == true) {
+      hive_HWC.close
+    }
+        
   }
   
   def close() {

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_DataFrame.scala
@@ -870,7 +870,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
           Values.Table_Name =dfTableName
           Values.BBDD_Name =dfDataBaseName
           Values.DF_Alias =AliasToQuery
-          Values.ColumnName =if (x.getFieldName == null) null else x.getFieldName.get_MyName()
+          Values.ColumnName =if (x.getFieldName == null) null else x.getFieldName.get_MyName(dMaster.getStorageType)
           Values.DQ_Name =x.getMyName()
           Values.DQ_Description =s"(Id ${x.getId}) ${x.getDescription}"
           Values.DQ_QueryLevel =x.getQueryLevel() // .getDQ_QueryLevel
@@ -910,7 +910,7 @@ class huemul_DataFrame(huemulBigDataGov: huemul_BigDataGovernance, Control: huem
             val SQL_Detail = DQ_GenQuery(AliasToQuery
                                         ,s"not (${x.getSQLFormula()})"
                                         ,!(x.getFieldName == null) //asField
-                                        ,if (x.getFieldName == null) "all" else x.getFieldName.get_MyName() //fieldName
+                                        ,if (x.getFieldName == null) "all" else x.getFieldName.get_MyName(dMaster.getStorageType) //fieldName
                                         ,Values.DQ_Id
                                         ,x.getNotification()
                                         ,x.getErrorCode()

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_ExternalDB.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_ExternalDB.scala
@@ -3,4 +3,7 @@ package com.huemulsolutions.bigdata.common
 class huemul_ExternalDB() extends Serializable {
     var Using_SPARK: huemul_ExternalDBType = new huemul_ExternalDBType().setActive(true).setActiveForHBASE(false)
     var Using_HIVE: huemul_ExternalDBType = new huemul_ExternalDBType()
+    var Using_HWC: huemul_ExternalDBType = new huemul_ExternalDBType()
+    
+    
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_ExternalHWC.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_ExternalHWC.scala
@@ -1,0 +1,36 @@
+package com.huemulsolutions.bigdata.common
+
+import com.hortonworks.hwc.HiveWarehouseSession
+import org.apache.spark.sql._
+import com.hortonworks.spark.sql.hive.llap.HiveWarehouseSessionImpl
+
+/**
+ * connect using Hortonworks Warehouse connector
+ * used by huemul_ExternalDB.Using_HWC 
+ */
+class huemul_ExternalHWC(huemulBigDataGov: huemul_BigDataGovernance) extends Serializable {
+  @transient private var _HWC_Hive: HiveWarehouseSessionImpl = null
+  def getHWC_Hive: HiveWarehouseSessionImpl = {
+    if (_HWC_Hive != null)
+      return _HWC_Hive
+      
+    _HWC_Hive = HiveWarehouseSession.session(huemulBigDataGov.spark).build()
+    
+
+    return _HWC_Hive
+  }
+  
+  def execute_NoResulSet(sql: String): Boolean = {
+    val _hive = getHWC_Hive
+    if (_hive == null)
+      sys.error("can't connect with HIVE, HiveWarehouseSession.session doesnt works")
+      
+    return _hive.executeUpdate(sql)
+  }
+  
+  def close {
+    val _hive = getHWC_Hive
+    if (_hive != null)
+      _hive.session().close()
+  }
+}

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_GlobalPath.scala
@@ -103,6 +103,16 @@ class huemul_GlobalPath() extends Serializable {
     * 
     */
     
+    //FROM 2.5 
+    //ADD AVRO SUPPORT
+    private var _avro_format: String = "com.databricks.spark.avro"
+    def getAVRO_format(): String = {return  _avro_format}
+    def setAVRO_format(value: String) {_avro_format = value} 
+    
+    private var _avro_compression: String = "snappy"
+    def getAVRO_compression(): String = {return  _avro_compression}
+    def setAVRO_compression(value: String) {_avro_compression = value} 
+    
     
     /**
      Returns true if path has value, otherwise return false

--- a/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/control/huemul_Control.scala
@@ -813,10 +813,11 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
         control_Columns_addOrUpd( LocalNewTable_id
                                  ,Column_Id
                                  ,i
-                                 ,x.get_MyName()
+                                 ,x.get_MyName(DefMaster.getStorageType)
                                  ,x.Description
                                  ,null //--as Column_Formula
                                  ,x.DataType.sql
+                                 ,x.getDataTypeDeploy(huemulBigDataGov.GlobalSettings.getBigDataProvider(), DefMaster.getStorageType).sql
                                  ,false //--as Column_SensibleData
                                  ,x.getMDM_EnableDTLog
                                  ,x.getMDM_EnableOldValue
@@ -863,9 +864,9 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
          x.Relationship.foreach { y => 
            control_TablesRelCol_add (IdRel
                                      ,PK_Id
-                                     ,y.PK.get_MyName()
+                                     ,y.PK.get_MyName(InstanceTable.getStorageType)
                                      ,LocalNewTable_id
-                                     ,y.FK.get_MyName() 
+                                     ,y.FK.get_MyName(DefMaster.getStorageType) 
                                      ,Control_ClassName)
           }
       }
@@ -2283,7 +2284,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
         huemulBigDataGov.logMessageInfo("control version: insert new version")
         val ExecResultCol = huemulBigDataGov.CONTROL_connection.ExecuteJDBC_NoResulSet(s"""
           INSERT INTO control_config (config_id, version_mayor, version_minor, version_patch)
-          VALUES (1,2,2,0)
+          VALUES (1,2,5,0)
           """)
           
           _version_mayor = 2
@@ -2483,6 +2484,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                              ,p_Column_Description: String
                              ,p_Column_Formula: String
                              ,p_Column_DataType: String
+                             ,p_Column_DataTypeDeploy: String
                              ,p_Column_SensibleData: Boolean
                              ,p_Column_EnableDTLog: Boolean
                              ,p_Column_EnableOldValue: Boolean
@@ -2526,7 +2528,8 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
           SET column_position	            = ${p_Column_Position}				
         		 ,column_description			    = CASE WHEN mdm_manualchange = 1 THEN column_description ELSE ${ReplaceSQLStringNulls(p_Column_Description,1000)}	END
         		 ,column_formula				      = CASE WHEN mdm_manualchange = 1 THEN column_formula ELSE ${ReplaceSQLStringNulls(p_Column_Formula,1000)}	END			
-        		 ,column_datatype				      = ${ReplaceSQLStringNulls(p_Column_DataType,50)}				
+        		 ,column_datatype				      = ${ReplaceSQLStringNulls(p_Column_DataType,50)}
+        	${if (getVersionFull() >= 20500) s",column_datatypedeploy = ${ReplaceSQLStringNulls(p_Column_DataTypeDeploy,50)} " else ""}	 
         		 ,column_sensibledata			    = CASE WHEN mdm_manualchange = 1 THEN column_sensibledata ELSE ${if (p_Column_SensibleData) "1" else "0"}	END		
         		 ,column_enabledtlog			    = ${if (p_Column_EnableDTLog) "1" else "0"}
         		 ,column_enableoldvalue			  = ${if (p_Column_EnableOldValue) "1" else "0"}
@@ -2561,6 +2564,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
                       								 ,column_description
                       								 ,column_formula
                       								 ,column_datatype
+    ${if (getVersionFull() >= 20500) s",column_datatypedeploy" else ""}	 
                       								 ,column_sensibledata
                       								 ,column_enabledtlog
                       								 ,column_enableoldvalue
@@ -2592,6 +2596,7 @@ class huemul_Control (phuemulBigDataGov: huemul_BigDataGovernance, ControlParent
             			 ,${ReplaceSQLStringNulls(p_Column_Description,1000)}
             			 ,${ReplaceSQLStringNulls(p_Column_Formula,1000)}
             			 ,${ReplaceSQLStringNulls(p_Column_DataType,50)}
+ ${if (getVersionFull() >= 20500) s",${ReplaceSQLStringNulls(p_Column_DataTypeDeploy,50)}" else ""}	             			 
             			 ,${if (p_Column_SensibleData) "1" else "0"}
             			 ,${if (p_Column_EnableDTLog) "1" else "0"}
             			 ,${if (p_Column_EnableOldValue) "1" else "0"}

--- a/src/main/scala/com/huemulsolutions/bigdata/datalake/huemulType_FileType.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/datalake/huemulType_FileType.scala
@@ -2,6 +2,6 @@ package com.huemulsolutions.bigdata.datalake
 
 object huemulType_FileType extends Enumeration {
   type huemulType_FileType = Value
-  val TEXT_FILE, PDF_FILE = Value
+  val TEXT_FILE, PDF_FILE, AVRO_FILE, PARQUET_FILE, ORC_FILE, DELTA_FILE = Value
   
 }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -1506,7 +1506,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     val __MDM_oldValue = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_oldValue")
     val __MDM_AutoInc = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_AutoInc")
     val __MDM_ProcessChange = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_ProcessChange")
-    val __MDM_columnName = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_columnName")
+    val __MDM_columnName = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_columnName").toLowerCase() //because it's partitioned column
     val __MDM_fhChange = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_fhChange")
     val __processExec_id = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "processExec_id")
     
@@ -3635,7 +3635,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"saving path: ${getFullNameWithPath_OldValueTrace()} ")
       if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET || getStorageType_OldValueTrace == huemulType_StorageType.ORC || 
           getStorageType_OldValueTrace == huemulType_StorageType.DELTA   || getStorageType_OldValueTrace == huemulType_StorageType.AVRO){
-        DF_Final.write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(_getSaveFormat(getStorageType_OldValueTrace)).save(getFullNameWithPath_OldValueTrace())
+        DF_Final.write.mode(SaveMode.Append).partitionBy("mdm_columnname").format(_getSaveFormat(getStorageType_OldValueTrace)).save(getFullNameWithPath_OldValueTrace())
         //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
         //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(_StorageType_OldValueTrace).save(GetFullNameWithPath_OldValueTrace())
       }
@@ -3677,7 +3677,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         if (this.getStorageType_OldValueTrace != huemulType_StorageType.DELTA) {
           LocalControl.NewStep("Save: OldVT Result: Repair Hive Metadata")
           val _refreshTable: String = s"MSCK REPAIR TABLE ${_tableNameOldValueTrace}"
-          if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"REFRESH TABLE ${_tableNameOldValueTrace}")
+          if (huemulBigDataGov.DebugMode) huemulBigDataGov.logMessageDebug(s"RMSCK REPAIR TABLE ${_tableNameOldValueTrace}")
           //new from 2.3
           runSQLexternalTable(_refreshTable, false)        
         }
@@ -3860,6 +3860,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //FOR HIVE
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getActiveForHBASE())
         huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getJDBC_connection(huemulBigDataGov).ExecuteJDBC_NoResulSet(sqlDrop01)
+        
+      //FOR HIVE WAREHOUSE CONNECTOR
+      if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE())
+        huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlDrop01)
     } else {
       /**** D R O P   F O R    O T H E R S ******/
       
@@ -3874,6 +3878,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //FOR HIVE
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getActive())
         huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getJDBC_connection(huemulBigDataGov).ExecuteJDBC_NoResulSet(sqlDrop01)
+        
+      //FOR HIVE WAREHOUSE CONNECTOR
+      if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActive())
+        huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlDrop01)
     }
     
   }
@@ -3891,6 +3899,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //FOR HIVE
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getActiveForHBASE())
           huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getJDBC_connection(huemulBigDataGov).ExecuteJDBC_NoResulSet(sqlSentence)
+          
+      //FOR HIVE WAREHOUSE CONNECTOR
+      if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE())
+          huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlSentence)
     } else {
       /**** D R O P   F O R   O T H E R ******/
       
@@ -3901,6 +3913,10 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       //FOR HIVE
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getActive())
         huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HIVE.getJDBC_connection(huemulBigDataGov).ExecuteJDBC_NoResulSet(sqlSentence)
+    
+      //FOR HIVE WAREHOUSE CONNECTOR
+      if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActive())
+        huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlSentence)
     
     }
   }
@@ -3922,3 +3938,4 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   
 
 }
+

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -3863,7 +3863,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         
       //FOR HIVE WAREHOUSE CONNECTOR
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE())
-        huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlDrop01)
+        huemulBigDataGov.getHive_HWC.execute_NoResulSet(sqlDrop01)
     } else {
       /**** D R O P   F O R    O T H E R S ******/
       
@@ -3881,7 +3881,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         
       //FOR HIVE WAREHOUSE CONNECTOR
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActive())
-        huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlDrop01)
+        huemulBigDataGov.getHive_HWC.execute_NoResulSet(sqlDrop01)
     }
     
   }
@@ -3902,7 +3902,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           
       //FOR HIVE WAREHOUSE CONNECTOR
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActiveForHBASE())
-          huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlSentence)
+          huemulBigDataGov.getHive_HWC.execute_NoResulSet(sqlSentence)
     } else {
       /**** D R O P   F O R   O T H E R ******/
       
@@ -3916,7 +3916,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     
       //FOR HIVE WAREHOUSE CONNECTOR
       if (huemulBigDataGov.GlobalSettings.externalBBDD_conf.Using_HWC.getActive())
-        huemulBigDataGov.hive_HWC.execute_NoResulSet(sqlSentence)
+        huemulBigDataGov.getHive_HWC.execute_NoResulSet(sqlSentence)
     
     }
   }

--- a/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/tables/huemul_Table.scala
@@ -403,7 +403,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
   val MDM_StatusReg = new huemul_Columns (IntegerType, true, "indica si el registro fue insertado en forma automática por otro proceso (1), o fue insertado por el proceso formal (2), si está eliminado (-1)", false).setHBaseCatalogMapping("loginfo")
   val MDM_hash = new huemul_Columns (StringType, true, "Valor hash de los datos de la tabla", false).setHBaseCatalogMapping("loginfo")
   
-  val MDM_columnName = new huemul_Columns (StringType, true, "Column Name", false).setHBaseCatalogMapping("loginfo")
+  val mdm_columnname = new huemul_Columns (StringType, true, "Column Name", false).setHBaseCatalogMapping("loginfo")
   
   //from 2.2 --> add rowKey compatibility with HBase
   val hs_rowKey = new huemul_Columns (StringType, true, "Concatenated PK", false).setHBaseCatalogMapping("loginfo")
@@ -608,8 +608,8 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
           }
         }
         else if (tableType == huemulType_InternalTableType.OldValueTrace) {
-          //create StructType MDM_columnName
-          if ("MDM_columnName".toLowerCase() != _colMyName) {
+          //create StructType mdm_columnname
+          if ("mdm_columnname".toLowerCase() != _colMyName) {
             fields = fields + s""",${dataField.getHBaseCatalogFamily()}:${dataField.getHBaseCatalogColumn()}#b"""
           }
         }
@@ -911,11 +911,11 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       
        
       if (tableType == huemulType_InternalTableType.OldValueTrace) {
-        b = b.filter { x => x.getName == "MDM_columnName" || x.getName == "MDM_newValue" || x.getName == "MDM_oldValue" || x.getName == "MDM_AutoInc" ||
+        b = b.filter { x => x.getName == "mdm_columnname" || x.getName == "MDM_newValue" || x.getName == "MDM_oldValue" || x.getName == "MDM_AutoInc" ||
                             x.getName == "MDM_fhChange" || x.getName == "MDM_ProcessChange" || x.getName == "processExec_id"  }
       } else {
         //exclude OldValuestrace columns
-        b = b.filter { x => x.getName != "MDM_columnName" && x.getName != "MDM_newValue" && x.getName != "MDM_oldValue" && x.getName != "MDM_AutoInc" && x.getName != "processExec_id"  }
+        b = b.filter { x => x.getName != "mdm_columnname" && x.getName != "MDM_newValue" && x.getName != "MDM_oldValue" && x.getName != "MDM_AutoInc" && x.getName != "processExec_id"  }
         
         if (this._TableType == huemulType_Tables.Transaction) 
           b = b.filter { x => x.getName != "MDM_ProcessChange" && x.getName != "MDM_fhChange" && x.getName != "MDM_StatusReg"   }
@@ -1201,12 +1201,12 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
         }
       }
       else if (tableType == huemulType_InternalTableType.OldValueTrace) {
-        //create StructType MDM_columnName
+        //create StructType mdm_columnname
         //FROM 2.4 --> INCLUDE PARTITIONED COLUMN IN CREATE TABLE ONLY FOR databricks COMPATIBILITY
         if (huemulBigDataGov.GlobalSettings.getBigDataProvider() == huemulType_bigDataProvider.databricks) {
           ColumnsCreateTable += s"$coma${_colMyName} ${DataTypeLocal} \n"
           coma = ","
-        } else if ("MDM_columnName".toLowerCase() != _colMyName.toLowerCase()) {
+        } else if ("mdm_columnname".toLowerCase() != _colMyName.toLowerCase()) {
           ColumnsCreateTable += s"$coma${_colMyName} ${DataTypeLocal} \n"
           coma = ","
         }
@@ -1506,7 +1506,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
     val __MDM_oldValue = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_oldValue")
     val __MDM_AutoInc = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_AutoInc")
     val __MDM_ProcessChange = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_ProcessChange")
-    val __MDM_columnName = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_columnName").toLowerCase() //because it's partitioned column
+    val __mdm_columnname = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "mdm_columnname").toLowerCase() //because it's partitioned column
     val __MDM_fhChange = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "MDM_fhChange")
     val __processExec_id = huemulBigDataGov.getCaseType( this.getStorageType_OldValueTrace, "processExec_id")
     
@@ -1531,7 +1531,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       val _colMyName = Field.get_MyName(this.getStorageType_OldValueTrace)
       val _dataType_MDM_fhChange = MDM_fhChange.getDataTypeDeploy(huemulBigDataGov.GlobalSettings.getBigDataProvider(), this.getStorageType_OldValueTrace)
       var __MDM_fhChange_cast: String = if (_dataType_MDM_fhChange == MDM_fhChange.DataType) s"now() as ${__MDM_fhChange}" else s"CAST(now() as STRING) as ${__MDM_fhChange}"
-      val StringSQL =  s"${StringSQl_PK_base}, CAST(new_${_colMyName} as string) AS ${__MDM_newValue}, CAST(old_${_colMyName} as string) AS ${__MDM_oldValue}, CAST(${_MDM_AutoInc} AS BIGINT) as ${__MDM_AutoInc}, cast('${Control.Control_Id}' as string) as ${__processExec_id}, ${__MDM_fhChange_cast}, cast('$ProcessName' as string) as ${__MDM_ProcessChange}, cast('${_colMyName.toLowerCase()}' as string) as ${__MDM_columnName} FROM $Alias WHERE ___ActionType__ = 'UPDATE' and __Change_${_colMyName} = 1 "
+      val StringSQL =  s"${StringSQl_PK_base}, CAST(new_${_colMyName} as string) AS ${__MDM_newValue}, CAST(old_${_colMyName} as string) AS ${__MDM_oldValue}, CAST(${_MDM_AutoInc} AS BIGINT) as ${__MDM_AutoInc}, cast('${Control.Control_Id}' as string) as ${__processExec_id}, ${__MDM_fhChange_cast}, cast('$ProcessName' as string) as ${__MDM_ProcessChange}, cast('${_colMyName.toLowerCase()}' as string) as ${__mdm_columnname} FROM $Alias WHERE ___ActionType__ = 'UPDATE' and __Change_${_colMyName} = 1 "
       val aliasFullTrace: String = s"__SQL_ovt_full_${_colMyName}"
       
       val tempSQL_OldValueFullTrace_DF = huemulBigDataGov.DF_ExecuteQuery(aliasFullTrace,StringSQL) 
@@ -2162,19 +2162,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                    CREATE TABLE IF NOT EXISTS ${internalGetTable(huemulType_InternalTableType.OldValueTrace)} (${getColumns_CreateTable(true, huemulType_InternalTableType.OldValueTrace) })
                                     ${if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET) {
                                      """USING PARQUET
-                                        PARTITIONED BY (MDM_columnName)""" 
+                                        PARTITIONED BY (mdm_columnname)""" 
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.ORC) {
                                      """USING ORC
-                                        PARTITIONED BY (MDM_columnName)""" 
+                                        PARTITIONED BY (mdm_columnname)""" 
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.DELTA) {
                                      """USING DELTA
-                                        PARTITIONED BY (MDM_columnName)""" 
+                                        PARTITIONED BY (mdm_columnname)""" 
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.AVRO) {
                                      s"""USING AVRO
-                                        PARTITIONED BY (MDM_columnName)""" 
+                                        PARTITIONED BY (mdm_columnname)""" 
                                     }
                                    }
                                    LOCATION '${getFullNameWithPath_OldValueTrace()}'"""
@@ -2195,19 +2195,19 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
                                       """
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET) {
-                                     """PARTITIONED BY (MDM_columnName STRING)
+                                     """PARTITIONED BY (mdm_columnname STRING)
                                        STORED AS PARQUET""" 
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.ORC) {
-                                     """PARTITIONED BY (MDM_columnName STRING)
+                                     """PARTITIONED BY (mdm_columnname STRING)
                                        STORED AS ORC""" 
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.DELTA) {
-                                     """PARTITIONED BY (MDM_columnName STRING)
+                                     """PARTITIONED BY (mdm_columnname STRING)
                                        STORED AS DELTA""" 
                                     }
                                     else if (getStorageType_OldValueTrace == huemulType_StorageType.AVRO) {
-                                     s"""PARTITIONED BY (MDM_columnName STRING)
+                                     s"""PARTITIONED BY (mdm_columnname STRING)
                                        STORED AS AVRO""" 
                                     }
                                    }
@@ -3636,7 +3636,7 @@ class huemul_Table(huemulBigDataGov: huemul_BigDataGovernance, Control: huemul_C
       if (getStorageType_OldValueTrace == huemulType_StorageType.PARQUET || getStorageType_OldValueTrace == huemulType_StorageType.ORC || 
           getStorageType_OldValueTrace == huemulType_StorageType.DELTA   || getStorageType_OldValueTrace == huemulType_StorageType.AVRO){
         DF_Final.write.mode(SaveMode.Append).partitionBy("mdm_columnname").format(_getSaveFormat(getStorageType_OldValueTrace)).save(getFullNameWithPath_OldValueTrace())
-        //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).partitionBy("MDM_columnName").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
+        //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).partitionBy("mdm_columnname").format(getStorageType_OldValueTrace.toString()).save(getFullNameWithPath_OldValueTrace())
         //DF_Final.coalesce(numPartitionsForDQFiles).write.mode(SaveMode.Append).format(_StorageType_OldValueTrace).save(GetFullNameWithPath_OldValueTrace())
       }
       else


### PR DESCRIPTION
Implementa las siguientes# Release 2.5
Este nuevo release contiene lo siguiente:

* [issue #106](https://github.com/HuemulSolutions/huemul-bigdatagovernance/issues/106): Leer archivos AVRO, PARQUET Y ORC e integrarlos a clase huemul_dataLake: Desde esta versión es posible utilizar archivos PARQUET, AVRO Y ORC como definición de RAW, de esta forma es posible incluir la trazabilidad de estos archivos cuando el DataLake ha sido formado a partir de estos formatos y no directamente desde los ficheros origen.
* [issue #107](https://github.com/HuemulSolutions/huemul-bigdatagovernance/issues/107): Compatibilidad con AVRO al guardar los datos con Huemul: Desde esta versión es posible utilizar AVRO como tipo de almacenamiento en Huemul. Al igual que PARQUET, puede ser utilizado para guardar tablas de tipo master como de tipo transaction.
* [issue #109](https://github.com/HuemulSolutions/huemul-bigdatagovernance/issues/109): Integración con Hive Warehouse Connector: Permite utilizar el HWC para crear la metadata de HIVE en ecosistemas Hortonworks versiones 3.0.0 y 3.1.14.
 mejoras:

