### PR TITLE
Feature scala212

### DIFF
--- a/huemul-bigdatagovernance.iml
+++ b/huemul-bigdatagovernance.iml
@@ -12,20 +12,19 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: com.huemulsolutions.bigdata:huemul-sql-decode:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.11.8" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-core_2.11:2.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.avro:avro:1.7.7" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.12.10" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-core_2.12:2.4.7" level="project" />
+    <orderEntry type="library" name="Maven: com.thoughtworks.paranamer:paranamer:2.8" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.avro:avro:1.8.2" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.13" level="project" />
-    <orderEntry type="library" name="Maven: com.thoughtworks.paranamer:paranamer:2.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.avro:avro-mapred:hadoop2:1.7.7" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.avro:avro-ipc:1.7.7" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.avro:avro-ipc:tests:1.7.7" level="project" />
-    <orderEntry type="library" name="Maven: com.twitter:chill_2.11:0.8.4" level="project" />
-    <orderEntry type="library" name="Maven: com.esotericsoftware:kryo-shaded:3.0.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.avro:avro-mapred:hadoop2:1.8.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.avro:avro-ipc:1.8.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.twitter:chill_2.12:0.9.3" level="project" />
+    <orderEntry type="library" name="Maven: com.esotericsoftware:kryo-shaded:4.0.2" level="project" />
     <orderEntry type="library" name="Maven: com.esotericsoftware:minlog:1.3.0" level="project" />
-    <orderEntry type="library" name="Maven: org.objenesis:objenesis:2.1" level="project" />
-    <orderEntry type="library" name="Maven: com.twitter:chill-java:0.8.4" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.xbean:xbean-asm5-shaded:4.4" level="project" />
+    <orderEntry type="library" name="Maven: org.objenesis:objenesis:2.5.1" level="project" />
+    <orderEntry type="library" name="Maven: com.twitter:chill-java:0.9.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xbean:xbean-asm6-shaded:4.8" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-client:2.6.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-hdfs:2.6.5" level="project" />
     <orderEntry type="library" name="Maven: org.htrace:htrace-core:3.0.4" level="project" />
@@ -37,17 +36,15 @@
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-yarn-api:2.6.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-mapreduce-client-jobclient:2.6.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-annotations:2.6.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-launcher_2.11:2.3.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-kvstore_2.11:2.3.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-launcher_2.12:2.4.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-kvstore_2.12:2.4.7" level="project" />
     <orderEntry type="library" name="Maven: org.fusesource.leveldbjni:leveldbjni-all:1.8" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-network-common_2.11:2.3.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-network-shuffle_2.11:2.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.spark:spark-unsafe_2.11:2.3.3" level="project" />
-    <orderEntry type="library" name="Maven: net.java.dev.jets3t:jets3t:0.9.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-network-common_2.12:2.4.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-network-shuffle_2.12:2.4.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-unsafe_2.12:2.4.7" level="project" />
     <orderEntry type="library" name="Maven: javax.activation:activation:1.1.1" level="project" />
-    <orderEntry type="library" name="Maven: com.jamesmurty.utils:java-xmlbuilder:1.1" level="project" />
-    <orderEntry type="library" name="Maven: net.iharder:base64:2.3.8" level="project" />
     <orderEntry type="library" name="Maven: org.apache.curator:curator-recipes:2.6.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.zookeeper:zookeeper:3.4.6" level="project" />
     <orderEntry type="library" name="Maven: javax.servlet:javax.servlet-api:3.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-math3:3.4.1" level="project" />
@@ -57,17 +54,17 @@
     <orderEntry type="library" name="Maven: org.slf4j:jcl-over-slf4j:1.7.16" level="project" />
     <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-log4j12:1.7.16" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.ning:compress-lzf:1.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.1.2.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.lz4:lz4-java:1.4.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.luben:zstd-jni:1.3.2-2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.roaringbitmap:RoaringBitmap:0.5.11" level="project" />
-    <orderEntry type="library" name="Maven: commons-net:commons-net:2.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-jackson_2.11:3.2.11" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-core_2.11:3.2.11" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-ast_2.11:3.2.11" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scalap:2.11.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scala-compiler:2.11.0" level="project" />
+    <orderEntry type="library" name="Maven: com.ning:compress-lzf:1.0.3" level="project" />
+    <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.1.7.5" level="project" />
+    <orderEntry type="library" name="Maven: org.lz4:lz4-java:1.4.0" level="project" />
+    <orderEntry type="library" name="Maven: com.github.luben:zstd-jni:1.3.2-2" level="project" />
+    <orderEntry type="library" name="Maven: org.roaringbitmap:RoaringBitmap:0.7.45" level="project" />
+    <orderEntry type="library" name="Maven: org.roaringbitmap:shims:0.7.45" level="project" />
+    <orderEntry type="library" name="Maven: commons-net:commons-net:3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-jackson_2.12:3.5.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-core_2.12:3.5.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-ast_2.12:3.5.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.json4s:json4s-scalap_2.12:3.5.3" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.core:jersey-client:2.22.2" level="project" />
     <orderEntry type="library" name="Maven: javax.ws.rs:javax.ws.rs-api:2.0.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.hk2:hk2-api:2.4.0-b34" level="project" />
@@ -82,101 +79,123 @@
     <orderEntry type="library" name="Maven: org.glassfish.jersey.core:jersey-server:2.22.2" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.media:jersey-media-jaxb:2.22.2" level="project" />
     <orderEntry type="library" name="Maven: javax.validation:validation-api:1.1.0.Final" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.glassfish.jersey.containers:jersey-container-servlet:2.22.2" level="project" />
+    <orderEntry type="library" name="Maven: org.glassfish.jersey.containers:jersey-container-servlet:2.22.2" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.containers:jersey-container-servlet-core:2.22.2" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-all:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-all:4.1.47.Final" level="project" />
     <orderEntry type="library" name="Maven: io.netty:netty:3.9.9.Final" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.clearspring.analytics:stream:2.7.0" level="project" />
+    <orderEntry type="library" name="Maven: com.clearspring.analytics:stream:2.7.0" level="project" />
     <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-core:3.1.5" level="project" />
     <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-jvm:3.1.5" level="project" />
     <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-json:3.1.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: io.dropwizard.metrics:metrics-graphite:3.1.5" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.6.7.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.fasterxml.jackson.module:jackson-module-scala_2.11:2.6.7.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.fasterxml.jackson.module:jackson-module-paranamer:2.7.9" level="project" />
+    <orderEntry type="library" name="Maven: io.dropwizard.metrics:metrics-graphite:3.1.5" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.6.7.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.fasterxml.jackson.module:jackson-module-scala_2.12:2.6.7.1" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-paranamer:2.7.9" level="project" />
     <orderEntry type="library" name="Maven: org.apache.ivy:ivy:2.4.0" level="project" />
     <orderEntry type="library" name="Maven: oro:oro:2.0.8" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.razorvine:pyrolite:4.13" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.sf.py4j:py4j:0.10.7" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.spark:spark-tags_2.11:2.3.3" level="project" />
+    <orderEntry type="library" name="Maven: net.razorvine:pyrolite:4.13" level="project" />
+    <orderEntry type="library" name="Maven: net.sf.py4j:py4j:0.10.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-tags_2.12:2.4.7" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-crypto:1.0.0" level="project" />
     <orderEntry type="library" name="Maven: org.spark-project.spark:unused:1.0.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-sql_2.11:2.3.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.univocity:univocity-parsers:2.5.9" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.spark:spark-sketch_2.11:2.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.spark:spark-catalyst_2.11:2.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.janino:janino:3.0.8" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.janino:commons-compiler:3.0.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-sql_2.12:2.4.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.univocity:univocity-parsers:2.7.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-sketch_2.12:2.4.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-catalyst_2.12:2.4.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.janino:janino:3.0.16" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.janino:commons-compiler:3.0.16" level="project" />
     <orderEntry type="library" name="Maven: org.antlr:antlr4-runtime:4.7" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.orc:orc-core:nohive:1.4.4" level="project" />
-    <orderEntry type="library" name="Maven: io.airlift:aircompressor:0.8" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.orc:orc-mapreduce:nohive:1.4.4" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-column:1.8.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-common:1.8.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-encoding:1.8.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-hadoop:1.8.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-format:2.3.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-jackson:1.8.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.arrow:arrow-vector:0.8.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.arrow:arrow-format:0.8.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.arrow:arrow-memory:0.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.orc:orc-core:nohive:1.5.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.orc:orc-shims:1.5.5" level="project" />
+    <orderEntry type="library" name="Maven: io.airlift:aircompressor:0.10" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.orc:orc-mapreduce:nohive:1.5.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-column:1.10.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-common:1.10.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-encoding:1.10.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-hadoop:1.10.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-format:2.4.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.parquet:parquet-jackson:1.10.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.arrow:arrow-vector:0.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.arrow:arrow-format:0.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.arrow:arrow-memory:0.10.0" level="project" />
     <orderEntry type="library" name="Maven: joda-time:joda-time:2.9.9" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.carrotsearch:hppc:0.7.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.vlkan:flatbuffers:1.2.0-3f79e055" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.spark:spark-streaming_2.11:2.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-jdbc:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-common:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-storage-api:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: com.carrotsearch:hppc:0.7.2" level="project" />
+    <orderEntry type="library" name="Maven: com.vlkan:flatbuffers:1.2.0-3f79e055" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-streaming_2.12:2.4.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-jdbc:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-common:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-classification:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-storage-api:2.7.0" level="project" />
     <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.orc:orc-core:1.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty.aggregate:jetty-all:7.6.0.v20120127" level="project" />
-    <orderEntry type="library" name="Maven: javax.mail:mail:1.4.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.geronimo.specs:geronimo-jaspic_1.0_spec:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.geronimo.specs:geronimo-annotation_1.0_spec:1.1.1" level="project" />
-    <orderEntry type="library" name="Maven: asm:asm-commons:3.1" level="project" />
-    <orderEntry type="library" name="Maven: asm:asm-tree:3.1" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-1.2-api:2.6.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.6.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.6.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-web:2.6.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-slf4j-impl:2.6.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.orc:orc-core:1.5.6" level="project" />
+    <orderEntry type="library" name="Maven: javax.xml.bind:jaxb-api:2.2.11" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-rewrite:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-client:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-server:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-servlet:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-security:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-webapp:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-xml:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-1.2-api:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-web:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-slf4j-impl:2.10.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.ant:ant:1.9.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.ant:ant-launcher:1.9.1" level="project" />
+    <orderEntry type="library" name="Maven: net.sf.jpam:jpam:1.1" level="project" />
     <orderEntry type="library" name="Maven: com.tdunning:json:1.8" level="project" />
     <orderEntry type="library" name="Maven: com.github.joshelser:dropwizard-metrics-hadoop-metrics2-reporter:0.1.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-service:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-server:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-common:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-tez:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.slider:slider-core:0.90.2-incubating" level="project" />
+    <orderEntry type="library" name="Maven: javolution:javolution:5.5.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-service:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-server:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-common:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-tez:3.1.2" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.jettison:jettison:1.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-common:test-jar:tests:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: net.sf.jpam:jpam:1.1" level="project" />
-    <orderEntry type="library" name="Maven: tomcat:jasper-compiler:5.5.23" level="project" />
-    <orderEntry type="library" name="Maven: javax.servlet:jsp-api:2.0" level="project" />
-    <orderEntry type="library" name="Maven: ant:ant:1.6.5" level="project" />
-    <orderEntry type="library" name="Maven: tomcat:jasper-runtime:5.5.23" level="project" />
-    <orderEntry type="library" name="Maven: commons-el:commons-el:1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-llap-common:test-jar:tests:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: javax.servlet.jsp:javax.servlet.jsp-api:2.3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-runner:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-plus:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-annotations:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm-commons:5.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm-tree:5.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-jaas:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty.websocket:websocket-server:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty.websocket:websocket-common:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty.websocket:websocket-api:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty.websocket:websocket-client:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty.websocket:websocket-servlet:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-jndi:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:apache-jsp:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty.toolchain:jetty-schemas:3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jdt.core.compiler:ecj:4.4.2" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.jetty:apache-jstl:9.3.20.v20170531" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.taglibs:taglibs-standard-spec:1.2.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.taglibs:taglibs-standard-impl:1.2.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.thrift:libfb303:0.9.3" level="project" />
     <orderEntry type="library" name="Maven: org.jamon:jamon-runtime:2.3.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-serde:2.3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-serde:3.1.2" level="project" />
     <orderEntry type="library" name="Maven: net.sf.opencsv:opencsv:2.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.parquet:parquet-hadoop-bundle:1.8.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-metastore:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: javolution:javolution:5.5.1" level="project" />
-    <orderEntry type="library" name="Maven: com.jolbox:bonecp:0.8.0.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: com.zaxxer:HikariCP:2.5.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.derby:derby:10.10.2.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.parquet:parquet-hadoop-bundle:1.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-metastore:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-standalone-metastore:3.1.2" level="project" />
     <orderEntry type="library" name="Maven: org.datanucleus:datanucleus-api-jdo:4.2.4" level="project" />
     <orderEntry type="library" name="Maven: org.datanucleus:datanucleus-core:4.1.17" level="project" />
     <orderEntry type="library" name="Maven: org.datanucleus:datanucleus-rdbms:4.1.19" level="project" />
+    <orderEntry type="library" name="Maven: org.datanucleus:javax.jdo:3.2.0-m3" level="project" />
+    <orderEntry type="library" name="Maven: javax.transaction:transaction-api:1.1" level="project" />
+    <orderEntry type="library" name="Maven: sqlline:sqlline:1.3.0" level="project" />
+    <orderEntry type="library" name="Maven: com.jolbox:bonecp:0.8.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: com.zaxxer:HikariCP:2.6.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.derby:derby:10.14.1.0" level="project" />
     <orderEntry type="library" name="Maven: commons-pool:commons-pool:1.5.4" level="project" />
     <orderEntry type="library" name="Maven: commons-dbcp:commons-dbcp:1.4" level="project" />
     <orderEntry type="library" name="Maven: javax.jdo:jdo-api:3.0.1" level="project" />
     <orderEntry type="library" name="Maven: javax.transaction:jta:1.1" level="project" />
-    <orderEntry type="library" name="Maven: org.datanucleus:javax.jdo:3.2.0-m3" level="project" />
-    <orderEntry type="library" name="Maven: javax.transaction:transaction-api:1.1" level="project" />
     <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.5.2" level="project" />
     <orderEntry type="library" name="Maven: co.cask.tephra:tephra-api:0.6.0" level="project" />
     <orderEntry type="library" name="Maven: co.cask.tephra:tephra-core:0.6.0" level="project" />
@@ -192,21 +211,23 @@
     <orderEntry type="library" name="Maven: org.apache.twill:twill-discovery-core:0.6.0-incubating" level="project" />
     <orderEntry type="library" name="Maven: org.apache.twill:twill-zookeeper:0.6.0-incubating" level="project" />
     <orderEntry type="library" name="Maven: co.cask.tephra:tephra-hbase-compat-1.0:0.6.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-shims:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive.shims:hive-shims-common:2.3.4" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hive.shims:hive-shims-0.23:2.3.4" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hadoop:hadoop-yarn-server-resourcemanager:2.7.2" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hadoop:hadoop-yarn-server-applicationhistoryservice:2.7.2" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hadoop:hadoop-yarn-server-web-proxy:2.7.2" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.zookeeper:zookeeper:test-jar:tests:3.4.6" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hive.shims:hive-shims-scheduler:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.hive:hive-service-rpc:2.3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.4" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-shims:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive.shims:hive-shims-common:3.1.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hive.shims:hive-shims-0.23:3.1.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hadoop:hadoop-yarn-server-resourcemanager:3.1.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hadoop:hadoop-yarn-server-applicationhistoryservice:3.1.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: de.ruedigermoeller:fst:2.50" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.cedarsoftware:java-util:1.9.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: com.cedarsoftware:json-io:2.5.1" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hadoop:hadoop-yarn-server-web-proxy:3.1.0" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.apache.hive.shims:hive-shims-scheduler:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-service-rpc:3.1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.thrift:libthrift:0.9.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.zookeeper:zookeeper:3.4.6" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.curator:curator-framework:2.7.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.curator:curator-client:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.curator:curator-framework:2.12.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.curator:curator-client:2.12.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.hive:hive-upgrade-acid:3.1.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase.connectors.spark:hbase-spark:1.0.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase.thirdparty:hbase-shaded-miscellaneous:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.yetus:audience-annotations:0.5.0" level="project" />
@@ -214,24 +235,14 @@
     <orderEntry type="library" name="Maven: org.apache.hbase.thirdparty:hbase-shaded-protobuf:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase.thirdparty:hbase-shaded-netty:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-http:2.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util:9.3.19.v20170502" level="project" />
     <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-util-ajax:9.3.19.v20170502" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-http:9.3.19.v20170502" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-security:9.3.19.v20170502" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-protocol-shaded:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-procedure:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-zookeeper:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-replication:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-metrics-api:2.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-metrics:2.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-server:9.3.19.v20170502" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-io:9.3.19.v20170502" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-servlet:9.3.19.v20170502" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-webapp:9.3.19.v20170502" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.jetty:jetty-xml:9.3.19.v20170502" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.web:javax.servlet.jsp:2.3.2" level="project" />
-    <orderEntry type="library" name="Maven: org.glassfish:javax.el:3.0.1-b12" level="project" />
-    <orderEntry type="library" name="Maven: javax.servlet.jsp:javax.servlet.jsp-api:2.3.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.htrace:htrace-core4:4.2.0-incubating" level="project" />
     <orderEntry type="library" name="Maven: com.lmax:disruptor:3.3.6" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hbase:hbase-mapreduce:2.1.0" level="project" />
@@ -239,14 +250,29 @@
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-mapreduce-client-core:2.7.7" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-yarn-common:2.7.7" level="project" />
-    <orderEntry type="library" name="Maven: javax.xml.bind:jaxb-api:2.2.2" level="project" />
-    <orderEntry type="library" name="Maven: javax.xml.stream:stax-api:1.0-2" level="project" />
     <orderEntry type="library" name="Maven: com.sun.jersey:jersey-client:1.9" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-jaxrs:1.9.13" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-xc:1.9.13" level="project" />
     <orderEntry type="library" name="Maven: com.sun.jersey.contribs:jersey-guice:1.9" level="project" />
     <orderEntry type="library" name="Maven: com.google.inject.extensions:guice-servlet:3.0" level="project" />
     <orderEntry type="library" name="Maven: org.scala-lang:scala-reflect:2.11.12" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-unsafe_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-tags_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: com.twitter:chill_2.11:0.9.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-catalyst_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang.modules:scala-parser-combinators_2.11:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-core_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-launcher_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-kvstore_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-network-common_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-network-shuffle_2.11:2.4.0" level="project" />
+    <orderEntry type="library" name="Maven: org.json4s:json4s-jackson_2.11:3.5.3" level="project" />
+    <orderEntry type="library" name="Maven: org.json4s:json4s-core_2.11:3.5.3" level="project" />
+    <orderEntry type="library" name="Maven: org.json4s:json4s-ast_2.11:3.5.3" level="project" />
+    <orderEntry type="library" name="Maven: org.json4s:json4s-scalap_2.11:3.5.3" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang.modules:scala-xml_2.11:1.0.6" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-scala_2.11:2.6.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.spark:spark-sketch_2.11:2.4.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-common:2.7.7" level="project" />
     <orderEntry type="library" name="Maven: xmlenc:xmlenc:0.52" level="project" />
     <orderEntry type="library" name="Maven: commons-httpclient:commons-httpclient:3.1" level="project" />
@@ -259,6 +285,8 @@
     <orderEntry type="library" name="Maven: com.sun.xml.bind:jaxb-impl:2.2.3-1" level="project" />
     <orderEntry type="library" name="Maven: com.sun.jersey:jersey-server:1.9" level="project" />
     <orderEntry type="library" name="Maven: asm:asm:3.1" level="project" />
+    <orderEntry type="library" name="Maven: net.java.dev.jets3t:jets3t:0.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.jamesmurty.utils:java-xmlbuilder:0.4" level="project" />
     <orderEntry type="library" name="Maven: commons-configuration:commons-configuration:1.6" level="project" />
     <orderEntry type="library" name="Maven: commons-digester:commons-digester:1.8" level="project" />
     <orderEntry type="library" name="Maven: commons-beanutils:commons-beanutils:1.7.0" level="project" />
@@ -432,19 +460,29 @@
     <orderEntry type="library" name="Maven: com.adobe.xmp:xmpcore:5.1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-core_2.11:3.7.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-matcher_2.11:3.7.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-common_2.11:3.7.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.spire-math:kind-projector_2.11:0.7.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scalaz:scalaz-core_2.11:7.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scalaz:scalaz-effect_2.11:7.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scalaz:scalaz-concurrent_2.11:7.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scalaz.stream:scalaz-stream_2.11:0.8a" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scodec:scodec-bits_2.11:1.0.12" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-junit_2.11:3.7.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest_2.11:3.0.0-M15" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.scalactic:scalactic_2.11:3.0.0-M15" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang.modules:scala-xml_2.11:1.0.2" level="project" />
-    <orderEntry type="library" name="Maven: org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-core_2.12:4.12.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-matcher_2.12:4.12.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-common_2.12:4.12.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-fp_2.12:4.12.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scala-sbt:test-interface:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.portable-scala:portable-scala-reflect_2.12:1.1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.specs2:specs2-junit_2.12:4.12.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang.modules:scala-xml_2.12:1.3.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-core_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-compatible:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalactic:scalactic_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-featurespec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-flatspec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-freespec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-funsuite_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-funspec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-propspec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-refspec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-wordspec_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-diagrams_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-matchers-core_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-shouldmatchers_2.12:3.2.9" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest-mustmatchers_2.12:3.2.9" level="project" />
   </component>
 </module>

--- a/huemul-bigdatagovernance.iml
+++ b/huemul-bigdatagovernance.iml
@@ -11,7 +11,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: com.huemulsolutions.bigdata:huemul-sql-decode:1.0" level="project" />
+    <orderEntry type="library" name="Maven: com.huemulsolutions.bigdata:huemul-sql-decode_2.12:1.0" level="project" />
     <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.12.10" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.spark:spark-core_2.12:2.4.7" level="project" />
     <orderEntry type="library" name="Maven: com.thoughtworks.paranamer:paranamer:2.8" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	    <groupId>org.apache.hbase.connectors.spark</groupId>
      	<artifactId>hbase-spark</artifactId>
     	<version>1.0.0</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.glassfish</groupId>
+                  <artifactId>javax.el</artifactId>
+              </exclusion>
+          </exclusions>
    	</dependency>
 
 
@@ -129,6 +135,12 @@ Finalmente, también automatiza la generación de código a partir de las defini
       <groupId>org.apache.hbase</groupId>
 	    <artifactId>hbase-client</artifactId>
 	    <version>1.1.2</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
   <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>2.6.3</version>
+  <version>2.6.3_2.12</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data lineage for BigData Projects.
 Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.
@@ -69,16 +69,16 @@ Finalmente, también automatiza la generación de código a partir de las defini
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.tools.version>2.11</scala.tools.version>
-    <scala.version>2.11.8</scala.version>
-    <spark.version>2.3.3</spark.version>
+    <scala.tools.version>2.12</scala.tools.version>
+    <scala.version>2.12.10</scala.version>
+    <spark.version>2.4.7</spark.version> <!-- spark version from sep 2020 -->
     <hbase.client.version>2.1.0</hbase.client.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.huemulsolutions.bigdata</groupId>
-      <artifactId>huemul-sql-decode</artifactId>
+      <artifactId>huemul-sql-decode_${scala.tools.version}</artifactId>
       <version>1.0</version>
     </dependency>
     <dependency>
@@ -107,7 +107,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	  <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
-      <version>2.3.4</version>
+      <version>3.1.2</version>
 	  </dependency>
 
 	  <dependency>
@@ -264,19 +264,19 @@ Finalmente, también automatiza la generación de código a partir de las defini
     <dependency>
       <groupId>org.specs2</groupId>
       <artifactId>specs2-core_${scala.tools.version}</artifactId>
-      <version>3.7.2</version>
+      <version>4.12.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.specs2</groupId>
       <artifactId>specs2-junit_${scala.tools.version}</artifactId>
-      <version>3.7.2</version>
+      <version>4.12.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.tools.version}</artifactId>
-      <version>3.0.0-M15</version>
+      <version>3.2.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -289,7 +289,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	  	<plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-gpg-plugin</artifactId>
-	      <version>1.5</version>
+	      <version>3.0.1</version>
 	      <executions>
 	        <execution>
 	          <id>sign-artifacts</id>
@@ -304,7 +304,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	    <plugin>
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-source-plugin</artifactId>
-	      <version>2.2.1</version>
+	      <version>3.2.1</version>
 	      <executions>
 	        <execution>
 	          <id>attach-sources</id>
@@ -318,7 +318,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
 	    <plugin>
 	      <groupId>net.alchim31.maven</groupId>
 	      <artifactId>scala-maven-plugin</artifactId>
-	      <version>3.4.2</version>
+	      <version>4.5.3</version>
 	      <executions>
 	        <execution>
 	          <id>attach-javadocs</id>
@@ -345,6 +345,12 @@ Finalmente, también automatiza la generación de código a partir de las defini
 
 
 <repositories>
+    <repository>
+        <id>central</id>
+        <name>Central Repository</name>
+        <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+
 	<repository>
      <id>hortonworks.extrepo</id>
      <name>Hortonworks HDP</name>
@@ -357,11 +363,7 @@ Finalmente, también automatiza la generación de código a partir de las defini
      <url>http://repo.hortonworks.com/content/groups/public</url>
     </repository>
     
-    <repository>
-      <id>central</id>
-      <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-    </repository>
+
 </repositories>
     <!--
    <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.huemulsolutions.bigdata</groupId>
-  <artifactId>huemul-bigdatagovernance</artifactId>
-  <version>2.6.3_2.12</version>
+  <artifactId>huemul-bigdatagovernance_2.12</artifactId>
+  <version>2.6.3</version>
   <name>HuemulSolutions - BigDataGovernance</name>
   <description>Enable full data quality and data lineage for BigData Projects.
 Huemul BigDataGovernance, es una librería que trabaja sobre Spark, Hive y HDFS. Permite la implementación de una **estrategia corporativa de dato único**, basada en buenas prácticas de Gobierno de Datos.

--- a/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
+++ b/src/main/scala/com/huemulsolutions/bigdata/common/huemul_BigDataGovernance.scala
@@ -41,7 +41,7 @@ import org.apache.log4j.{Level, Logger}
  *  @param LocalSparkSession(opcional) permite enviar una sesión de Spark ya iniciada.
  */
 class huemul_BigDataGovernance (appName: String, args: Array[String], globalSettings: huemul_GlobalPath, LocalSparkSession: SparkSession = null) extends Serializable  {
-  val currentVersion: String = "2.6.3"
+  val currentVersion: String = "2.6.3_2.12"
   val GlobalSettings: huemul_GlobalPath = globalSettings
   val warehouseLocation: String = new File("spark-warehouse").getAbsolutePath
   //@transient lazy val log_info = org.apache.log4j.LogManager.getLogger(s"$appName [with huemul]")
@@ -483,7 +483,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
       val minutesWait = this.getDateTimeDiff(startWaitingTime, Calendar.getInstance())
       val minutesWaiting = ((minutesWait.days * 24) + minutesWait.hour) * 60 + minutesWait.minute
 
-      logMessageError(s"waiting for singleton (${minutesWaiting} out of ${globalSettings.getMaxMinutesWaitInSingleton} minutes) Application Id in use: $IdApplication, maybe you're creating two times a spark connection")
+      logMessageError(s"waiting for singleton ($minutesWaiting out of ${globalSettings.getMaxMinutesWaitInSingleton} minutes) Application Id in use: $IdApplication, maybe you're creating two times a spark connection")
 
       //from 2.6.3
       if (application_StillAlive(IdApplication)) {
@@ -493,7 +493,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
         //numAttempt is consecutive
         if (numAttempt > globalSettings.getMaxAttemptApplicationInUse) {
           //Si no existe ejecución vigente, debe invocar proceso que limpia proceso
-          application_closeAll(IdApplication, false)
+          application_closeAll(IdApplication, closeExecutors = false)
           continueWaiting = false
         } else
           numAttempt += 1
@@ -600,7 +600,7 @@ class huemul_BigDataGovernance (appName: String, args: Array[String], globalSett
         if (result2 == 0)
           IdAppFromAPI = idFromURL2
         else
-          logMessageWarn(s"can't get url: return: ${result2}")
+          logMessageWarn(s"can't get url: return: $result2")
 
 
       } catch {


### PR DESCRIPTION
Upgrade de scala, desde 2.11 a 2.12, plan de pruebas 100% exitoso, se evidencia el siguiente cambio en comportamiento :

Al ejecutar la consulta

`
spark.sql("select cast('  1 ' as int) as num").show()
`
en versión 2.3 de spark retorna NULL, mientras que en versión 3.x de spark retorna 1.
En resumen, la versión 3.x de spark tiene el comportamiento esperado de esta transformación.
